### PR TITLE
Fix use of already open file when writing netlist

### DIFF
--- a/skidl/skidl.py
+++ b/skidl/skidl.py
@@ -457,11 +457,8 @@ class SchLib(object):
         export_str += '{} = SchLib(tool=SKIDL).add_parts(*[{}])'.format(
             cnvt_to_var_name(libname), part_export_str)
         export_str = prettify(export_str)
-        try:
-            file_.write(export_str)
-        except AttributeError:
-            with open(file_, 'w') as f:
-                f.write(export_str)
+        with opened(file_, "w") as f:
+            f.write(export_str)
 
     def __len__(self):
         """
@@ -3259,16 +3256,10 @@ class Circuit(object):
                 '{} errors found during netlist generation.\n\n'.format(
                     logger.error.count))
 
-        try:
-            with file_ as f:
-                f.write(netlist)
-        except AttributeError:
-            try:
-                with open(file_, 'w') as f:
-                    f.write(netlist)
-            except (FileNotFoundError, TypeError):
-                with open(get_script_name() + '.net', 'w') as f:
-                    f.write(netlist)
+        with opened(
+                file_ or (get_script_name() + '.net'),
+                'w') as f:
+            f.write(netlist)
 
         if do_backup:
             self.backup_parts()  # Create a new backup lib for the circuit parts.
@@ -3334,16 +3325,11 @@ class Circuit(object):
                 '{} errors found during XML generation.\n\n'.format(
                     logger.error.count))
 
-        try:
-            with file_ as f:
-                f.write(netlist)
-        except AttributeError:
-            try:
-                with open(file_, 'w') as f:
-                    f.write(netlist)
-            except (FileNotFoundError, TypeError):
-                with open(get_script_name() + '.xml', 'w') as f:
-                    f.write(netlist)
+        with opened(
+                file_ or (get_script_name() + '.xml'),
+                'w') as f:
+            f.write(netlist)
+
         return netlist
 
     def _gen_xml_kicad(self):

--- a/skidl/utilities.py
+++ b/skidl/utilities.py
@@ -49,6 +49,8 @@ import logging
 import inspect
 import traceback
 
+from contextlib import contextmanager
+
 from .py_2_3 import *
 
 
@@ -535,3 +537,27 @@ def find_num_copies(**attribs):
         return max(num_copies)
     except ValueError:
         return 0  # If the list if empty.
+
+@contextmanager
+def opened(f_or_fn, mode):
+    """
+    Yields an opened file or file-like object.
+
+    Args:
+       file_or_filename: Either an already opened file or file-like
+           object, or a filename to open.
+       mode: The mode to open the file in.
+    """
+    if isinstance(f_or_fn, basestring):
+        with open(f_or_fn, mode) as f:
+            yield f
+    elif hasattr(f_or_fn, "fileno"):
+        if mode.replace("+", "") == f_or_fn.mode.replace("+", ""):
+            # same mode, can reuse file handle
+            yield f_or_fn
+        else:
+            # open in new mode
+            with os.fdopen(f_or_fn.fileno(), mode) as f:
+                yield f
+    else:
+        raise TypeError("argument must be a filename or a file-like object (is: {})".format(type(f_or_fn)))


### PR DESCRIPTION
When calling generate_netlist with an already open file (ie
sys.stdin), the file would get closed by the use as a context manager:

    with file_ as f:
        f.write(netlist)

I added a little helper "opened()" in utilities that fixes this
problem and also makes the code much simpler.