### PR TITLE
Exclude tests from setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author_email=__email__,
     url='https://github.com/xesscorp/skidl',
 #    packages=['skidl',],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     entry_points={'console_scripts':['netlist_to_skidl = skidl.netlist_to_skidl_main:main']},
     package_dir={'skidl': 'skidl'},
     include_package_data=True,


### PR DESCRIPTION
Tests should not be installed by setuptools, since it will put them in site-packages/tests. This is likely to conflict with other packages, and is against the packaging guidelines of at least Arch, and probably other distros as well.

Also, skidl (and kinparse) is in the AUR now, so Arch users can install it with just <aur helper of choice> python-skidl. At the moment, I'm patching this at build time.