### PR TITLE
More explicit installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ takes an input voltage, divides it by three, and outputs it::
     vin, vout, gnd = Net('VI'), Net('VO'), Net('GND')
 
     # Create two resistors.
-    r1, r2 = 2 * Part('device', 'R', TEMPLATE, footprint='Resistors_SMD:R_0805')
+    r1, r2 = 2 * Part('device', 'R', TEMPLATE, footprint='KiCad/Resistors_SMD.pretty:R_0805')
     r1.value = '1K'   # Set upper resistor value.
     r2.value = '500'  # Set lower resistor value.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,16 +122,19 @@ SKiDL is pure Python so it's easy to install:
 $ pip install skidl
 ```
 
-or:
-
-```bash
-$ easy_install skidl
-```
-
 In order for SKiDL to access part libraries,
 you'll also need to install [KiCad](http://kicad-pcb.org/).
 
+Last but not least, make sure you define the following environment variables on your `.bashrc`, i.e, for OSX:
 
+```
+# KiCad/SKidl
+export KISYSMOD="/Library/Application Support/kicad/modules/"
+export KICAD_SYMBOL_DIR="/Library/Application Support/kicad/library"
+```
+
+Those paths are operating system-dependent so launching KiCAD and going to `Preferences->Configure Paths`
+will reveal the needed paths.
 
 # Basic Usage
 


### PR DESCRIPTION
For some reason I keep forgetting to setup the required environment variables on different machines and the out and the error is a bit puzzling every time I encounter it:

```
$ python readme_skidl.py
ERROR: Can't open file: device.

WARNING: Could not load KiCad schematic library "device", falling back to backup library.
Traceback (most recent call last):
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/tools/kicad.py", line 69, in _load_sch_lib_
    f, _ = find_and_open_file(filename, lib_search_paths_, lib_suffixes[KICAD])
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/utilities.py", line 258, in find_and_open_file
    raise FileNotFoundError
FileNotFoundError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "readme_skidl.py", line 7, in <module>
    r1, r2 = 2 * Part('device', 'R', TEMPLATE, footprint='Resistors_SMD:R_0603')
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/Part.py", line 139, in __init__
    raise e
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/Part.py", line 131, in __init__
    lib = SchLib(filename=libname, tool=tool)
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/SchLib.py", line 96, in __init__
    load_func(filename, skidl.lib_search_paths[tool])
  File "/Users/romanvg/.miniconda/envs/kicad/lib/python3.7/site-packages/skidl/tools/kicad.py", line 73, in _load_sch_lib_
    filename, str(e)))
Exception: Unable to open KiCad Schematic Library File device ()
```

So this changeset should solve it right away and generate a correct netlist. `easy_install` is kind of deprecated so I removed it too from the docs and explained the need for the `KI*` environment variables before running any script and how to find them.

OTOH, I don't know if the `.pretty` change on README.rst is required only for KiCad 4.x, in which case I'll revert the change right away in this PR (still have not updated to KiCad 5.x :-S).