### PR TITLE
Change log.error() & throw to just throw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# IntelliJ IDEA & pycharm
+.idea
+
+# virtualenvs
+venv
+
 *.py[cod]
 *.bak
 

--- a/skidl/Bus.py
+++ b/skidl/Bus.py
@@ -164,10 +164,9 @@ class Bus(SkidlBaseObject):
                     self.nets.insert(index, n)
                 index += len(obj)
             else:
-                logger.error(
+                raise ValueError(
                     'Adding illegal type of object ({}) to Bus {}.'.format(
                         type(obj), self.name))
-                raise Exception
 
         # Assign names to all the unnamed nets in the bus.
         for i, net in enumerate(self.nets):
@@ -181,8 +180,7 @@ class Bus(SkidlBaseObject):
 
     def get_pins(self):
         """It's an error to get the list of pins attached to all bus lines."""
-        logger.error("Can't get the list of pins on a bus!")
-        raise Exception
+        raise ValueError("Can't get the list of pins on a bus!")
 
     def copy(self, num_copies=None, **attribs):
         """
@@ -222,15 +220,13 @@ class Bus(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            logger.error(
+            raise ValueError(
                 "Can't make a non-integer number ({}) of copies of a bus!".
-                format(num_copies))
-            raise Exception
+                    format(num_copies))
         if num_copies < 0:
-            logger.error(
+            raise ValueError(
                 "Can't make a negative number ({}) of copies of a bus!".format(
                     num_copies))
-            raise Exception
 
         copies = []
         for i in range(num_copies):
@@ -243,10 +239,9 @@ class Bus(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        logger.error(
+                        raise ValueError(
                             "{} copies of bus {} were requested, but too few elements in attribute {}!".
-                            format(num_copies, self.name, k))
-                        raise Exception
+                                format(num_copies, self.name, k))
                 setattr(cpy, k, v)
 
             copies.append(cpy)
@@ -288,8 +283,7 @@ class Bus(SkidlBaseObject):
             elif isinstance(ident, basestring):
                 nets.extend(filter_list(self.nets, name=ident))
             else:
-                logger.error("Can't index bus with a {}.".format(type(ident)))
-                raise Exception
+                raise ValueError("Can't index bus with a {}.".format(type(ident)))
 
         if len(nets) == 0:
             # No nets were selected from the bus, so return None.
@@ -331,8 +325,7 @@ class Bus(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        logger.error("Can't assign to a bus! Use the += operator.")
-        raise Exception
+        raise ValueError("Can't assign to a bus! Use the += operator.")
 
     def __iter__(self):
         """

--- a/skidl/Bus.py
+++ b/skidl/Bus.py
@@ -164,7 +164,7 @@ class Bus(SkidlBaseObject):
                     self.nets.insert(index, n)
                 index += len(obj)
             else:
-                raise ValueError(
+                log_and_raise(logger, ValueError,
                     'Adding illegal type of object ({}) to Bus {}.'.format(
                         type(obj), self.name))
 
@@ -180,7 +180,7 @@ class Bus(SkidlBaseObject):
 
     def get_pins(self):
         """It's an error to get the list of pins attached to all bus lines."""
-        raise TypeError("Can't get the list of pins on a bus!")
+        log_and_raise(logger, TypeError, "Can't get the list of pins on a bus!")
 
     def copy(self, num_copies=None, **attribs):
         """
@@ -220,11 +220,11 @@ class Bus(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a non-integer number ({}) of copies of a bus!".
-                    format(num_copies))
+                          format(num_copies))
         if num_copies < 0:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a negative number ({}) of copies of a bus!".format(
                     num_copies))
 
@@ -239,9 +239,9 @@ class Bus(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        raise ValueError(
+                        log_and_raise(logger, ValueError,
                             "{} copies of bus {} were requested, but too few elements in attribute {}!".
-                                format(num_copies, self.name, k))
+                                      format(num_copies, self.name, k))
                 setattr(cpy, k, v)
 
             copies.append(cpy)
@@ -283,7 +283,7 @@ class Bus(SkidlBaseObject):
             elif isinstance(ident, basestring):
                 nets.extend(filter_list(self.nets, name=ident))
             else:
-                raise TypeError("Can't index bus with a {}.".format(type(ident)))
+                log_and_raise(logger, TypeError, "Can't index bus with a {}.".format(type(ident)))
 
         if len(nets) == 0:
             # No nets were selected from the bus, so return None.
@@ -325,7 +325,7 @@ class Bus(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise TypeError("Can't assign to a bus! Use the += operator.")
+        log_and_raise(logger, TypeError, "Can't assign to a bus! Use the += operator.")
 
     def __iter__(self):
         """

--- a/skidl/Bus.py
+++ b/skidl/Bus.py
@@ -180,7 +180,7 @@ class Bus(SkidlBaseObject):
 
     def get_pins(self):
         """It's an error to get the list of pins attached to all bus lines."""
-        raise ValueError("Can't get the list of pins on a bus!")
+        raise TypeError("Can't get the list of pins on a bus!")
 
     def copy(self, num_copies=None, **attribs):
         """
@@ -283,7 +283,7 @@ class Bus(SkidlBaseObject):
             elif isinstance(ident, basestring):
                 nets.extend(filter_list(self.nets, name=ident))
             else:
-                raise ValueError("Can't index bus with a {}.".format(type(ident)))
+                raise TypeError("Can't index bus with a {}.".format(type(ident)))
 
         if len(nets) == 0:
             # No nets were selected from the bus, so return None.
@@ -325,7 +325,7 @@ class Bus(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise ValueError("Can't assign to a bus! Use the += operator.")
+        raise TypeError("Can't assign to a bus! Use the += operator.")
 
     def __iter__(self):
         """

--- a/skidl/Circuit.py
+++ b/skidl/Circuit.py
@@ -170,10 +170,9 @@ class Circuit(SkidlBaseObject):
                     self.parts.append(part)
 
                 else:
-                    logger.error(
+                    raise ValueError(
                         "Can't add unmovable part {} to this circuit.".format(
                             part.ref))
-                    raise Exception
 
     def rmv_parts(self, *parts):
         """Remove some Part objects from the circuit."""
@@ -188,9 +187,8 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent part {} from this circuit.".
                         format(part.ref))
             else:
-                logger.error("Can't remove part {} from this circuit.".format(
+                raise ValueError("Can't remove part {} from this circuit.".format(
                     part.ref))
-                raise Exception
 
     def add_nets(self, *nets):
         """Add some Net objects to the circuit. Assign a net name if necessary."""
@@ -211,10 +209,9 @@ class Circuit(SkidlBaseObject):
                     self.nets.append(net)
 
                 else:
-                    logger.error(
+                    raise ValueError(
                         "Can't add unmovable net {} to this circuit.".format(
                             net.name))
-                    raise Exception
 
     def rmv_nets(self, *nets):
         """Remove some Net objects from the circuit."""
@@ -229,10 +226,9 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent net {} from this circuit.".
                         format(net.name))
             else:
-                logger.error(
+                raise ValueError(
                     "Can't remove unmovable net {} from this circuit.".format(
                         net.name))
-                raise Exception
 
     def add_buses(self, *buses):
         """Add some Bus objects to the circuit. Assign a bus name if necessary."""
@@ -270,10 +266,9 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent bus {} from this circuit.".
                         format(bus.name))
             else:
-                logger.error(
+                raise ValueError(
                     "Can't remove unmovable bus {} from this circuit.".format(
                         bus.name))
-                raise Exception
 
     def add_interfaces(self, *interfaces):
         """Add some Interface objects to the circuit. Assign an interface name if necessary."""
@@ -307,10 +302,9 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent interface {} from this circuit.".
                         format(interface.name))
             else:
-                logger.error(
+                raise ValueError(
                     "Can't remove unmovable interface {} from this circuit.".format(
                         interface.name))
-                raise Exception
 
     def add_stuff(self, *stuff):
         """Add Parts, Nets, Buses, and Interfaces to the circuit."""
@@ -330,9 +324,8 @@ class Circuit(SkidlBaseObject):
             elif isinstance(thing, Interface):
                 self.add_interfaces(thing)
             else:
-                logger.error("Can't add a {} to a Circuit object.".format(
+                raise ValueError("Can't add a {} to a Circuit object.".format(
                     type(thing)))
-                raise Exception
         return self
 
     def rmv_stuff(self, *stuff):
@@ -353,9 +346,8 @@ class Circuit(SkidlBaseObject):
             elif isinstance(thing, Interface):
                 self.rmv_interfaces(thing)
             else:
-                logger.error("Can't remove a {} from a Circuit object.".format(
+                raise ValueError("Can't remove a {} from a Circuit object.".format(
                     type(pnb)))
-                raise Exception
         return self
 
     __iadd__ = add_stuff
@@ -432,10 +424,9 @@ class Circuit(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_{}'.format(tool))
             netlist = gen_func(**kwargs)  # Pass any remaining arguments.
         except KeyError:
-            logger.error(
+            raise ValueError(
                 "Can't generate netlist in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+                    format(tool))
 
         if (logger.error.count, logger.warning.count) == (0, 0):
             sys.stderr.write(
@@ -486,10 +477,9 @@ class Circuit(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_{}'.format(tool))
             netlist = gen_func()
         except KeyError:
-            logger.error(
+            raise ValueError(
                 "Can't generate XML in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+                    format(tool))
 
         if (logger.error.count, logger.warning.count) == (0, 0):
             sys.stderr.write(

--- a/skidl/Circuit.py
+++ b/skidl/Circuit.py
@@ -170,7 +170,7 @@ class Circuit(SkidlBaseObject):
                     self.parts.append(part)
 
                 else:
-                    raise ValueError(
+                    log_and_raise(logger, ValueError,
                         "Can't add unmovable part {} to this circuit.".format(
                             part.ref))
 
@@ -187,7 +187,8 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent part {} from this circuit.".
                         format(part.ref))
             else:
-                raise ValueError("Can't remove part {} from this circuit.".format(
+                log_and_raise(logger, ValueError,
+                    "Can't remove part {} from this circuit.".format(
                     part.ref))
 
     def add_nets(self, *nets):
@@ -209,7 +210,7 @@ class Circuit(SkidlBaseObject):
                     self.nets.append(net)
 
                 else:
-                    raise ValueError(
+                    log_and_raise(logger, ValueError,
                         "Can't add unmovable net {} to this circuit.".format(
                             net.name))
 
@@ -226,7 +227,7 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent net {} from this circuit.".
                         format(net.name))
             else:
-                raise ValueError(
+                log_and_raise(logger, ValueError,
                     "Can't remove unmovable net {} from this circuit.".format(
                         net.name))
 
@@ -266,7 +267,7 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent bus {} from this circuit.".
                         format(bus.name))
             else:
-                raise ValueError(
+                log_and_raise(logger, ValueError,
                     "Can't remove unmovable bus {} from this circuit.".format(
                         bus.name))
 
@@ -302,7 +303,7 @@ class Circuit(SkidlBaseObject):
                         "Removing non-existent interface {} from this circuit.".
                         format(interface.name))
             else:
-                raise ValueError(
+                log_and_raise(logger, ValueError,
                     "Can't remove unmovable interface {} from this circuit.".format(
                         interface.name))
 
@@ -324,7 +325,7 @@ class Circuit(SkidlBaseObject):
             elif isinstance(thing, Interface):
                 self.add_interfaces(thing)
             else:
-                raise ValueError("Can't add a {} to a Circuit object.".format(
+                log_and_raise(logger, ValueError,"Can't add a {} to a Circuit object.".format(
                     type(thing)))
         return self
 
@@ -346,7 +347,7 @@ class Circuit(SkidlBaseObject):
             elif isinstance(thing, Interface):
                 self.rmv_interfaces(thing)
             else:
-                raise ValueError("Can't remove a {} from a Circuit object.".format(
+                log_and_raise(logger, ValueError,"Can't remove a {} from a Circuit object.".format(
                     type(pnb)))
         return self
 
@@ -424,7 +425,7 @@ class Circuit(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_{}'.format(tool))
             netlist = gen_func(**kwargs)  # Pass any remaining arguments.
         except KeyError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate netlist in an unknown ECAD tool format ({}).".
                     format(tool))
 
@@ -477,7 +478,7 @@ class Circuit(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_{}'.format(tool))
             netlist = gen_func()
         except KeyError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate XML in an unknown ECAD tool format ({}).".
                     format(tool))
 

--- a/skidl/Net.py
+++ b/skidl/Net.py
@@ -193,7 +193,7 @@ class Net(SkidlBaseObject):
                 if self.is_attached(net):
                     return True
             return False
-        raise ValueError("Nets can't be attached to {}!".format(type(pin_net_bus)))
+        raise TypeError("Nets can't be attached to {}!".format(type(pin_net_bus)))
 
     def is_movable(self):
         """
@@ -363,7 +363,7 @@ class Net(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise ValueError("Can't assign to a Net! Use the += operator.")
+        raise TypeError("Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -484,7 +484,7 @@ class Net(SkidlBaseObject):
                         "Can't attach a part to a net in different circuits ({}, {})!"
                             .format(pn.part.circuit.name, self.circuit.name))
             else:
-                raise ValueError(
+                raise TypeError(
                     'Cannot attach non-Pin/non-Net {} to Net {}.'.format(
                         type(pn), self.name))
 

--- a/skidl/Net.py
+++ b/skidl/Net.py
@@ -193,7 +193,7 @@ class Net(SkidlBaseObject):
                 if self.is_attached(net):
                     return True
             return False
-        raise TypeError("Nets can't be attached to {}!".format(type(pin_net_bus)))
+        log_and_raise(logger, TypeError, "Nets can't be attached to {}!".format(type(pin_net_bus)))
 
     def is_movable(self):
         """
@@ -247,11 +247,11 @@ class Net(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a non-integer number "
                 "({}) of copies of a net!".format(num_copies))
         if num_copies < 0:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a negative number "
                 "({}) of copies of a net!".format(num_copies))
 
@@ -267,7 +267,7 @@ class Net(SkidlBaseObject):
         # to search for all the other copies to add the pin to those.
         # And what's the value of that?
         if self.pins:
-            raise ValueError("Can't make copies of a net that already has "
+            log_and_raise(logger, ValueError, "Can't make copies of a net that already has "
                              "pins attached to it!")
 
         # Create a list of copies of this net.
@@ -287,8 +287,8 @@ class Net(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        raise ValueError(
-                            ("{} copies of net {} were requested, but too "
+                        log_and_raise(logger, ValueError,
+                                      ("{} copies of net {} were requested, but too "
                              "few elements in attribute {}!"
                              ).format(num_copies, self.name, k))
                 setattr(cpy, k, v)
@@ -329,9 +329,9 @@ class Net(SkidlBaseObject):
         if indices is None or len(indices) == 0:
             return None
         if len(indices) > 1:
-            raise ValueError("Can't index a net with multiple indices.")
+            log_and_raise(logger, ValueError, "Can't index a net with multiple indices.")
         if indices[0] != 0:
-            raise ValueError("Can't use a non-zero index for a net.")
+            log_and_raise(logger, ValueError, "Can't use a non-zero index for a net.")
         return self
 
     def __setitem__(self, ids, *pins_nets_buses):
@@ -363,7 +363,7 @@ class Net(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise TypeError("Can't assign to a Net! Use the += operator.")
+        log_and_raise(logger, TypeError, "Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -411,11 +411,11 @@ class Net(SkidlBaseObject):
             """
 
             if isinstance(self, NCNet):
-                raise ValueError("Can't merge with a no-connect net {}!".format(
+                log_and_raise(logger, ValueError, "Can't merge with a no-connect net {}!".format(
                     self.name))
 
             if isinstance(net, NCNet):
-                raise ValueError("Can't merge with a no-connect net {}!".format(
+                log_and_raise(logger, ValueError, "Can't merge with a no-connect net {}!".format(
                     net.name))
 
             # No need to do anything if merging a net with itself.
@@ -469,9 +469,9 @@ class Net(SkidlBaseObject):
                 if pn.circuit == self.circuit:
                     merge(pn)
                 else:
-                    raise ValueError(
+                    log_and_raise(logger, ValueError,
                         "Can't attach nets in different circuits ({}, {})!"
-                            .format(pn.circuit.name, self.circuit.name))
+                                  .format(pn.circuit.name, self.circuit.name))
             elif isinstance(pn, Pin):
                 if not pn.part or pn.part.circuit == self.circuit:
                     if not pn.part:
@@ -480,11 +480,11 @@ class Net(SkidlBaseObject):
                                 pn.name, self.name))
                     connect_pin(pn)
                 else:
-                    raise ValueError(
+                    log_and_raise(logger, ValueError,
                         "Can't attach a part to a net in different circuits ({}, {})!"
-                            .format(pn.part.circuit.name, self.circuit.name))
+                                  .format(pn.part.circuit.name, self.circuit.name))
             else:
-                raise TypeError(
+                log_and_raise(logger, TypeError,
                     'Cannot attach non-Pin/non-Net {} to Net {}.'.format(
                         type(pn), self.name))
 
@@ -532,9 +532,9 @@ class Net(SkidlBaseObject):
                 if fixed1 and not fixed0:
                     return nets[1]
                 if fixed0 and fixed1:
-                    raise ValueError(
+                    log_and_raise(logger, ValueError,
                         'Cannot merge two nets with fixed names: {} and {}.'
-                            .format(name0, name1))
+                                  .format(name0, name1))
                 if nets[1].is_implicit():
 
                     return nets[0]
@@ -618,9 +618,9 @@ class Net(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_net_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate netlist in an unknown ECAD tool format ({})."
-                    .format(tool))
+                          .format(tool))
 
     def generate_xml_net(self, tool=None):
         """
@@ -645,9 +645,9 @@ class Net(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_net_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate XML in an unknown ECAD tool format ({})."
-                    .format(tool))
+                          .format(tool))
 
     def ERC(self, *args, **kwargs):
         """Run class-wide and local ERC functions on this net."""
@@ -741,9 +741,9 @@ class Net(SkidlBaseObject):
             pass
         elif len(netclasses) == 1:
             if netclass not in netclasses:
-                raise ValueError("Can't assign net class {netclass.name} to net {self.name} that's already assigned net class {netclasses}".format(**locals()))
+                log_and_raise(logger, ValueError, "Can't assign net class {netclass.name} to net {self.name} that's already assigned net class {netclasses}".format(**locals()))
         else:
-            raise ValueError("Too many netclasses assigned to net {self.name}".format(**locals()))
+            log_and_raise(logger, ValueError, "Too many netclasses assigned to net {self.name}".format(**locals()))
 
         for n in nets:
             n._netclass = netclass
@@ -800,7 +800,7 @@ class Net(SkidlBaseObject):
     def test_validity(self):
         if self.valid:
             return
-        raise ValueError('Net {} is no longer valid. Do not use it!'.format(
+        log_and_raise(logger, ValueError, 'Net {} is no longer valid. Do not use it!'.format(
             self.name))
 
     def __bool__(self):

--- a/skidl/Net.py
+++ b/skidl/Net.py
@@ -193,8 +193,7 @@ class Net(SkidlBaseObject):
                 if self.is_attached(net):
                     return True
             return False
-        logger.error("Nets can't be attached to {}!".format(type(pin_net_bus)))
-        raise Exception
+        raise ValueError("Nets can't be attached to {}!".format(type(pin_net_bus)))
 
     def is_movable(self):
         """
@@ -248,15 +247,13 @@ class Net(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            logger.error(
-                "Can't make a non-integer number ({}) of copies of a net!".
-                format(num_copies))
-            raise Exception
+            raise ValueError(
+                "Can't make a non-integer number "
+                "({}) of copies of a net!".format(num_copies))
         if num_copies < 0:
-            logger.error(
-                "Can't make a negative number ({}) of copies of a net!".format(
-                    num_copies))
-            raise Exception
+            raise ValueError(
+                "Can't make a negative number "
+                "({}) of copies of a net!".format(num_copies))
 
         # If circuitis not specified, then create the copies within the circuit of the master.
         # If the master isn't in a circuit, then use the default circuit.
@@ -270,10 +267,8 @@ class Net(SkidlBaseObject):
         # to search for all the other copies to add the pin to those.
         # And what's the value of that?
         if self.pins:
-            logger.error(
-                "Can't make copies of a net that already has pins attached to it!"
-            )
-            raise Exception
+            raise ValueError("Can't make copies of a net that already has "
+                             "pins attached to it!")
 
         # Create a list of copies of this net.
         copies = []
@@ -292,11 +287,12 @@ class Net(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        logger.error(
-                            "{} copies of net {} were requested, but too few elements in attribute {}!".
-                            format(num_copies, self.name, k))
-                        raise Exception
+                        raise ValueError(
+                            ("{} copies of net {} were requested, but too "
+                             "few elements in attribute {}!"
+                             ).format(num_copies, self.name, k))
                 setattr(cpy, k, v)
+
 
             # Place the copy into the list of copies.
             copies.append(cpy)
@@ -333,11 +329,9 @@ class Net(SkidlBaseObject):
         if indices is None or len(indices) == 0:
             return None
         if len(indices) > 1:
-            logger.error("Can't index a net with multiple indices.")
-            raise Exception
+            raise ValueError("Can't index a net with multiple indices.")
         if indices[0] != 0:
-            logger.error("Can't use a non-zero index for a net.")
-            raise Exception
+            raise ValueError("Can't use a non-zero index for a net.")
         return self
 
     def __setitem__(self, ids, *pins_nets_buses):
@@ -369,8 +363,7 @@ class Net(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        logger.error("Can't assign to a Net! Use the += operator.")
-        raise Exception
+        raise ValueError("Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -418,14 +411,12 @@ class Net(SkidlBaseObject):
             """
 
             if isinstance(self, NCNet):
-                logger.error("Can't merge with a no-connect net {}!".format(
+                raise ValueError("Can't merge with a no-connect net {}!".format(
                     self.name))
-                raise Exception
 
             if isinstance(net, NCNet):
-                logger.error("Can't merge with a no-connect net {}!".format(
+                raise ValueError("Can't merge with a no-connect net {}!".format(
                     net.name))
-                raise Exception
 
             # No need to do anything if merging a net with itself.
             if self == net:
@@ -478,10 +469,9 @@ class Net(SkidlBaseObject):
                 if pn.circuit == self.circuit:
                     merge(pn)
                 else:
-                    logger.error(
-                        "Can't attach nets in different circuits ({}, {})!".
-                        format(pn.circuit.name, self.circuit.name))
-                    raise Exception
+                    raise ValueError(
+                        "Can't attach nets in different circuits ({}, {})!"
+                            .format(pn.circuit.name, self.circuit.name))
             elif isinstance(pn, Pin):
                 if not pn.part or pn.part.circuit == self.circuit:
                     if not pn.part:
@@ -490,15 +480,13 @@ class Net(SkidlBaseObject):
                                 pn.name, self.name))
                     connect_pin(pn)
                 else:
-                    logger.error(
-                        "Can't attach a part to a net in different circuits ({}, {})!".
-                        format(pn.part.circuit.name, self.circuit.name))
-                    raise Exception
+                    raise ValueError(
+                        "Can't attach a part to a net in different circuits ({}, {})!"
+                            .format(pn.part.circuit.name, self.circuit.name))
             else:
-                logger.error(
+                raise ValueError(
                     'Cannot attach non-Pin/non-Net {} to Net {}.'.format(
                         type(pn), self.name))
-                raise Exception
 
         # Add the net to the global netlist. (It won't be added again
         # if it's already there.)
@@ -544,11 +532,11 @@ class Net(SkidlBaseObject):
                 if fixed1 and not fixed0:
                     return nets[1]
                 if fixed0 and fixed1:
-                    logger.error(
-                        'Cannot merge two nets with fixed names: {} and {}.'.format(
-                            name0, name1))
-                    raise Exception
+                    raise ValueError(
+                        'Cannot merge two nets with fixed names: {} and {}.'
+                            .format(name0, name1))
                 if nets[1].is_implicit():
+
                     return nets[0]
                 if nets[0].is_implicit():
                     return nets[1]
@@ -630,10 +618,9 @@ class Net(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_net_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            logger.error(
-                "Can't generate netlist in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+            raise ValueError(
+                "Can't generate netlist in an unknown ECAD tool format ({})."
+                    .format(tool))
 
     def generate_xml_net(self, tool=None):
         """
@@ -658,10 +645,9 @@ class Net(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_net_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            logger.error(
-                "Can't generate XML in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+            raise ValueError(
+                "Can't generate XML in an unknown ECAD tool format ({})."
+                    .format(tool))
 
     def ERC(self, *args, **kwargs):
         """Run class-wide and local ERC functions on this net."""
@@ -755,11 +741,9 @@ class Net(SkidlBaseObject):
             pass
         elif len(netclasses) == 1:
             if netclass not in netclasses:
-                logger.error("Can't assign net class {netclass.name} to net {self.name} that's already assigned net class {netclasses}".format(**locals()))
-                raise Exception
+                raise ValueError("Can't assign net class {netclass.name} to net {self.name} that's already assigned net class {netclasses}".format(**locals()))
         else:
-            logger.error("Too many netclasses assigned to net {self.name}".format(**locals()))
-            raise Exception
+            raise ValueError("Too many netclasses assigned to net {self.name}".format(**locals()))
 
         for n in nets:
             n._netclass = netclass
@@ -816,9 +800,8 @@ class Net(SkidlBaseObject):
     def test_validity(self):
         if self.valid:
             return
-        logger.error('Net {} is no longer valid. Do not use it!'.format(
+        raise ValueError('Net {} is no longer valid. Do not use it!'.format(
             self.name))
-        raise Exception
 
     def __bool__(self):
         """Any valid Net is True"""

--- a/skidl/NetPinList.py
+++ b/skidl/NetPinList.py
@@ -47,15 +47,13 @@ class NetPinList(list):
             if isinstance(item, (Pin, Net)):
                 nets_pins.append(item)
             else:
-                logger.error("Can't make connections to a {} ({}).".format(
+                raise ValueError("Can't make connections to a {} ({}).".format(
                     type(item), item.__name__))
-                raise Exception
 
         if len(nets_pins) != len(self):
             if Net in [type(item) for item in self] or len(nets_pins) > 1:
-                logger.error("Connection mismatch {} != {}!".format(
+                raise ValueError("Connection mismatch {} != {}!".format(
                     len(self), len(nets_pins)))
-                raise Exception
 
             # If just a single net is to be connected, make a list out of it that's
             # just as long as the list of pins to connect to. This will connect
@@ -113,12 +111,12 @@ class NetPinList(list):
     # might be returned by the filter_list() utility.
     @property
     def aliases(self):
-        raise Exception
+        raise NotImplementedError
 
     @aliases.setter
     def aliases(self, alias):
-        raise Exception
+        raise NotImplementedError
 
     @aliases.deleter
     def aliases(self):
-        raise Exception
+        raise NotImplementedError

--- a/skidl/NetPinList.py
+++ b/skidl/NetPinList.py
@@ -47,13 +47,15 @@ class NetPinList(list):
             if isinstance(item, (Pin, Net)):
                 nets_pins.append(item)
             else:
-                raise ValueError("Can't make connections to a {} ({}).".format(
-                    type(item), item.__name__))
+                log_and_raise(logger, ValueError,
+                              "Can't make connections to a {} ({}).".format(
+                                type(item), item.__name__))
 
         if len(nets_pins) != len(self):
             if Net in [type(item) for item in self] or len(nets_pins) > 1:
-                raise ValueError("Connection mismatch {} != {}!".format(
-                    len(self), len(nets_pins)))
+                log_and_raise(logger, ValueError,
+                              "Connection mismatch {} != {}!".format(
+                                len(self), len(nets_pins)))
 
             # If just a single net is to be connected, make a list out of it that's
             # just as long as the list of pins to connect to. This will connect

--- a/skidl/Network.py
+++ b/skidl/Network.py
@@ -45,7 +45,7 @@ class Network(list):
                 ntwk = obj.create_network(
                 )  # Create a Network from each object.
             except AttributeError:
-                raise ValueError(
+                raise TypeError(
                     "Can't create a network from a {} object ({}).".format(
                         type(obj), obj.__name__))
 
@@ -68,7 +68,7 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            raise ValueError(
+            raise TypeError(
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
 
@@ -94,7 +94,7 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            raise ValueError(
+            raise TypeError(
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
 

--- a/skidl/Network.py
+++ b/skidl/Network.py
@@ -45,10 +45,10 @@ class Network(list):
                 ntwk = obj.create_network(
                 )  # Create a Network from each object.
             except AttributeError:
-                logger.error(
+                raise ValueError(
                     "Can't create a network from a {} object ({}).".format(
                         type(obj), obj.__name__))
-                raise Exception
+
 
             # Add the in & out ports of the object network to this network.
             self.extend(ntwk)
@@ -58,9 +58,8 @@ class Network(list):
             # have zero, in which case it is just an empty container waiting to
             # have ports added to it.
             if len(self) > 2:
-                logger.error(
-                    "A Network object can't have more than two nodes.")
-                raise Exception
+                raise ValueError("A Network object can't have more than two nodes.")
+
 
     def __and__(self, obj):
         """Combine two networks by placing them in series."""
@@ -69,10 +68,10 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            logger.error(
+            raise ValueError(
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
-            raise Exception
+
 
         # Attach the output of the first network to the input of the second.
         # (Use -1 index to get the output port instead of 1 because the network
@@ -95,10 +94,9 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            logger.error(
+            raise ValueError(
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
-            raise Exception
 
         # Attach the inputs of both networks and the outputs of both networks to
         # place them in parallel.

--- a/skidl/Network.py
+++ b/skidl/Network.py
@@ -45,7 +45,7 @@ class Network(list):
                 ntwk = obj.create_network(
                 )  # Create a Network from each object.
             except AttributeError:
-                raise TypeError(
+                log_and_raise(logger, TypeError,
                     "Can't create a network from a {} object ({}).".format(
                         type(obj), obj.__name__))
 
@@ -58,7 +58,8 @@ class Network(list):
             # have zero, in which case it is just an empty container waiting to
             # have ports added to it.
             if len(self) > 2:
-                raise ValueError("A Network object can't have more than two nodes.")
+                log_and_raise(logger, ValueError,
+                              "A Network object can't have more than two nodes.")
 
 
     def __and__(self, obj):
@@ -68,7 +69,7 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            raise TypeError(
+            log_and_raise(logger, TypeError,
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
 
@@ -94,7 +95,7 @@ class Network(list):
         try:
             ntwk = obj.create_network()
         except AttributeError:
-            raise TypeError(
+            log_and_raise(logger, TypeError,
                 "Unable to create a Network from a {} object ({}).".format(
                     type(obj), obj.__name__))
 

--- a/skidl/Part.py
+++ b/skidl/Part.py
@@ -172,9 +172,9 @@ class Part(SkidlBaseObject):
             pass
 
         else:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a part without a library & part name or a part definition."
-            )
+                          )
 
         # If the part is going to be an element in a circuit, then add it to the
         # the circuit and make any indicated pin/net connections.
@@ -271,9 +271,9 @@ class Part(SkidlBaseObject):
         try:
             parse_func = getattr(self, '_parse_lib_part_{}'.format(self.tool))
         except AttributeError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't create a part with an unknown ECAD tool file format: {}."
-                    .format(self.tool))
+                          .format(self.tool))
 
         # Parse the part description.
         parse_func(just_get_name)
@@ -330,13 +330,13 @@ class Part(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a non-integer number ({}) of copies of a part!".
-                    format(num_copies))
+                          format(num_copies))
         if num_copies < 0:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a negative number ({}) of copies of a part!".
-                    format(num_copies))
+                          format(num_copies))
 
         # Now make copies of the part one-by-one.
         copies = []
@@ -404,9 +404,9 @@ class Part(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        raise ValueError(
+                        log_and_raise(logger, ValueError,
                             "{} copies of part {} were requested, but too few elements in attribute {}!"
-                                .format(num_copies, self.name, k))
+                                      .format(num_copies, self.name, k))
                 setattr(cpy, k, v)
 
             # Add the part copy to the list of copies.
@@ -568,7 +568,8 @@ class Part(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise TypeError("Can't assign to a part! Use the += operator.")
+        log_and_raise(logger, TypeError,
+                      "Can't assign to a part! Use the += operator.")
 
     def is_connected(self):
         """
@@ -636,7 +637,8 @@ class Part(SkidlBaseObject):
             add_unique_attr(self, alias, pin)
         else:
             # Error: either 0 or multiple pins were found.
-            raise ValueError('Cannot set alias for {}'.format(pin_ids))
+            log_and_raise(logger, ValueError,
+                          'Cannot set alias for {}'.format(pin_ids))
 
     def make_unit(self, label, *pin_ids, **criteria):
         """
@@ -741,9 +743,9 @@ class Part(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_comp_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate netlist in an unknown ECAD tool format ({}).".
-                    format(tool))
+                          format(tool))
 
     def generate_xml_component(self, tool=None):
         """
@@ -762,9 +764,9 @@ class Part(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_comp_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't generate XML in an unknown ECAD tool format ({}).".
-                    format(tool))
+                          format(tool))
 
     def ERC(self, *args, **kwargs):
         """Run class-wide and local ERC functions on this part."""

--- a/skidl/Part.py
+++ b/skidl/Part.py
@@ -568,7 +568,7 @@ class Part(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise ValueError("Can't assign to a part! Use the += operator.")
+        raise TypeError("Can't assign to a part! Use the += operator.")
 
     def is_connected(self):
         """

--- a/skidl/Part.py
+++ b/skidl/Part.py
@@ -133,10 +133,10 @@ class Part(SkidlBaseObject):
             # If the lib argument is a string, then create a library using the
             # string as the library file name.
             if isinstance(lib, basestring):
+                libname = lib
                 try:
-                    libname = lib
                     lib = SchLib(filename=libname, tool=tool)
-                except Exception as e:
+                except FileNotFoundError as e:
                     if skidl.QUERY_BACKUP_LIB:
                         logger.warning(
                             'Could not load KiCad schematic library "{}", falling back to backup library.'
@@ -172,10 +172,9 @@ class Part(SkidlBaseObject):
             pass
 
         else:
-            logger.error(
+            raise ValueError(
                 "Can't make a part without a library & part name or a part definition."
             )
-            raise Exception
 
         # If the part is going to be an element in a circuit, then add it to the
         # the circuit and make any indicated pin/net connections.
@@ -272,10 +271,9 @@ class Part(SkidlBaseObject):
         try:
             parse_func = getattr(self, '_parse_lib_part_{}'.format(self.tool))
         except AttributeError:
-            logger.error(
+            raise ValueError(
                 "Can't create a part with an unknown ECAD tool file format: {}."
-                .format(self.tool))
-            raise Exception
+                    .format(self.tool))
 
         # Parse the part description.
         parse_func(just_get_name)
@@ -332,15 +330,13 @@ class Part(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            logger.error(
+            raise ValueError(
                 "Can't make a non-integer number ({}) of copies of a part!".
-                format(num_copies))
-            raise Exception
+                    format(num_copies))
         if num_copies < 0:
-            logger.error(
+            raise ValueError(
                 "Can't make a negative number ({}) of copies of a part!".
-                format(num_copies))
-            raise Exception
+                    format(num_copies))
 
         # Now make copies of the part one-by-one.
         copies = []
@@ -408,10 +404,9 @@ class Part(SkidlBaseObject):
                     try:
                         v = v[i]
                     except IndexError:
-                        logger.error(
+                        raise ValueError(
                             "{} copies of part {} were requested, but too few elements in attribute {}!"
-                            .format(num_copies, self.name, k))
-                        raise Exception
+                                .format(num_copies, self.name, k))
                 setattr(cpy, k, v)
 
             # Add the part copy to the list of copies.
@@ -573,8 +568,7 @@ class Part(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        logger.error("Can't assign to a part! Use the += operator.")
-        raise Exception
+        raise ValueError("Can't assign to a part! Use the += operator.")
 
     def is_connected(self):
         """
@@ -642,8 +636,7 @@ class Part(SkidlBaseObject):
             add_unique_attr(self, alias, pin)
         else:
             # Error: either 0 or multiple pins were found.
-            logger.error('Cannot set alias for {}'.format(pin_ids))
-            raise Exception
+            raise ValueError('Cannot set alias for {}'.format(pin_ids))
 
     def make_unit(self, label, *pin_ids, **criteria):
         """
@@ -748,10 +741,9 @@ class Part(SkidlBaseObject):
             gen_func = getattr(self, '_gen_netlist_comp_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            logger.error(
+            raise ValueError(
                 "Can't generate netlist in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+                    format(tool))
 
     def generate_xml_component(self, tool=None):
         """
@@ -770,10 +762,9 @@ class Part(SkidlBaseObject):
             gen_func = getattr(self, '_gen_xml_comp_{}'.format(tool))
             return gen_func()
         except AttributeError:
-            logger.error(
+            raise ValueError(
                 "Can't generate XML in an unknown ECAD tool format ({}).".
-                format(tool))
-            raise Exception
+                    format(tool))
 
     def ERC(self, *args, **kwargs):
         """Run class-wide and local ERC functions on this part."""

--- a/skidl/Part.py
+++ b/skidl/Part.py
@@ -36,8 +36,8 @@ from builtins import int
 from builtins import range
 from builtins import dict
 from builtins import zip
-from future import standard_library
-standard_library.install_aliases()
+
+from .py_2_3 import *  # pylint: disable=wildcard-import
 
 try:
     import __builtin__ as builtins

--- a/skidl/Pin.py
+++ b/skidl/Pin.py
@@ -229,11 +229,11 @@ class Pin(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a non-integer number ({}) of copies of a pin!".
-                    format(num_copies))
+                          format(num_copies))
         if num_copies < 0:
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 "Can't make a negative number ({}) of copies of a pin!".format(
                     num_copies))
 
@@ -291,9 +291,9 @@ class Pin(SkidlBaseObject):
         if indices is None or len(indices) == 0:
             return None
         if len(indices) > 1:
-            raise ValueError("Can't index a pin with multiple indices.")
+            log_and_raise(logger, ValueError, "Can't index a pin with multiple indices.")
         if indices[0] != 0:
-            raise ValueError("Can't use a non-zero index for a pin.")
+            log_and_raise(logger, ValueError, "Can't use a non-zero index for a pin.")
         return self
 
     def __setitem__(self, ids, *pins_nets_buses):
@@ -325,7 +325,7 @@ class Pin(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise TypeError("Can't assign to a Net! Use the += operator.")
+        log_and_raise(logger, TypeError, "Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -354,11 +354,12 @@ class Pin(SkidlBaseObject):
             return True
         if set([Net, NCNet]) == net_types:
             # Can't be connected to both normal and no-connect nets!
-            raise ValueError(
+            log_and_raise(logger, ValueError,
                 '{} is connected to both normal and no-connect nets!'.format(
                     self.erc_desc()))
         # This is just strange...
-        raise ValueError("{} is connected to something strange: {}.".format(
+        log_and_raise(logger, ValueError,
+            "{} is connected to something strange: {}.".format(
             self.erc_desc(), self.nets))
 
     def is_attached(self, pin_net_bus):
@@ -380,7 +381,8 @@ class Pin(SkidlBaseObject):
                 if self.net.is_attached(net):
                     return True
             return False
-        raise ValueError("Pins can't be attached to {}!".format(type(pin_net_bus)))
+        log_and_raise(logger, ValueError,
+            "Pins can't be attached to {}!".format(type(pin_net_bus)))
 
     def connect(self, *pins_nets_buses):
         """
@@ -423,7 +425,8 @@ class Pin(SkidlBaseObject):
                 # Connecting pin-to-net, so just connect the pin to the net.
                 pn += self
             else:
-                raise TypeError('Cannot attach non-Pin/non-Net {} to {}.'.format(
+                log_and_raise(logger, TypeError,
+                    'Cannot attach non-Pin/non-Net {} to {}.'.format(
                     type(pn), self.erc_desc()))
 
         # Set the flag to indicate this result came from the += operator.

--- a/skidl/Pin.py
+++ b/skidl/Pin.py
@@ -325,7 +325,7 @@ class Pin(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        raise ValueError("Can't assign to a Net! Use the += operator.")
+        raise TypeError("Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -423,7 +423,7 @@ class Pin(SkidlBaseObject):
                 # Connecting pin-to-net, so just connect the pin to the net.
                 pn += self
             else:
-                raise ValueError('Cannot attach non-Pin/non-Net {} to {}.'.format(
+                raise TypeError('Cannot attach non-Pin/non-Net {} to {}.'.format(
                     type(pn), self.erc_desc()))
 
         # Set the flag to indicate this result came from the += operator.

--- a/skidl/Pin.py
+++ b/skidl/Pin.py
@@ -229,15 +229,13 @@ class Pin(SkidlBaseObject):
 
         # Check that a valid number of copies is requested.
         if not isinstance(num_copies, int):
-            logger.error(
+            raise ValueError(
                 "Can't make a non-integer number ({}) of copies of a pin!".
-                format(num_copies))
-            raise Exception
+                    format(num_copies))
         if num_copies < 0:
-            logger.error(
+            raise ValueError(
                 "Can't make a negative number ({}) of copies of a pin!".format(
                     num_copies))
-            raise Exception
 
         copies = []
         for _ in range(num_copies):
@@ -293,11 +291,9 @@ class Pin(SkidlBaseObject):
         if indices is None or len(indices) == 0:
             return None
         if len(indices) > 1:
-            logger.error("Can't index a pin with multiple indices.")
-            raise Exception
+            raise ValueError("Can't index a pin with multiple indices.")
         if indices[0] != 0:
-            logger.error("Can't use a non-zero index for a pin.")
-            raise Exception
+            raise ValueError("Can't use a non-zero index for a pin.")
         return self
 
     def __setitem__(self, ids, *pins_nets_buses):
@@ -329,8 +325,7 @@ class Pin(SkidlBaseObject):
 
         # No iadd_flag or it wasn't set. This means a direct assignment
         # was made to the pin, which is not allowed.
-        logger.error("Can't assign to a Net! Use the += operator.")
-        raise Exception
+        raise ValueError("Can't assign to a Net! Use the += operator.")
 
     def __iter__(self):
         """
@@ -359,14 +354,12 @@ class Pin(SkidlBaseObject):
             return True
         if set([Net, NCNet]) == net_types:
             # Can't be connected to both normal and no-connect nets!
-            logger.error(
+            raise ValueError(
                 '{} is connected to both normal and no-connect nets!'.format(
                     self.erc_desc()))
-            raise Exception
         # This is just strange...
-        logger.error("{} is connected to something strange: {}.".format(
+        raise ValueError("{} is connected to something strange: {}.".format(
             self.erc_desc(), self.nets))
-        raise Exception
 
     def is_attached(self, pin_net_bus):
         """Return true if this pin is attached to the given pin, net or bus."""
@@ -387,8 +380,7 @@ class Pin(SkidlBaseObject):
                 if self.net.is_attached(net):
                     return True
             return False
-        logger.error("Pins can't be attached to {}!".format(type(pin_net_bus)))
-        raise Exception
+        raise ValueError("Pins can't be attached to {}!".format(type(pin_net_bus)))
 
     def connect(self, *pins_nets_buses):
         """
@@ -431,9 +423,8 @@ class Pin(SkidlBaseObject):
                 # Connecting pin-to-net, so just connect the pin to the net.
                 pn += self
             else:
-                logger.error('Cannot attach non-Pin/non-Net {} to {}.'.format(
+                raise ValueError('Cannot attach non-Pin/non-Net {} to {}.'.format(
                     type(pn), self.erc_desc()))
-                raise Exception
 
         # Set the flag to indicate this result came from the += operator.
         self.iadd_flag = True  # pylint: disable=attribute-defined-outside-init

--- a/skidl/SchLib.py
+++ b/skidl/SchLib.py
@@ -90,7 +90,8 @@ class SchLib(object):
                 load_func = getattr(self, '_load_sch_lib_{}'.format(tool))
             except AttributeError:
                 # OK, that didn't work so well...
-                raise ValueError('Unsupported ECAD tool library: {}.'.format(tool))
+                log_and_raise(logger, ValueError,
+                              'Unsupported ECAD tool library: {}.'.format(tool))
             else:
                 load_func(filename, skidl.lib_search_paths[tool])
                 self.filename = filename
@@ -166,9 +167,11 @@ class SchLib(object):
 
             # No part with that alias either, so signal an error.
             if not parts:
-                raise ValueError(
-                    'Unable to find part {} in library {}.'.format(
-                        name, getattr(self, 'filename', 'UNKNOWN')))
+                message = 'Unable to find part {} in library {}.'.format(
+                    name, getattr(self, 'filename', 'UNKNOWN'))
+                if not silent:
+                    logger.error(message)
+                raise ValueError(message)
 
         # Multiple parts with that name or alias exists, so return the list
         # of parts or just the first part on the list.

--- a/skidl/SchLib.py
+++ b/skidl/SchLib.py
@@ -90,8 +90,7 @@ class SchLib(object):
                 load_func = getattr(self, '_load_sch_lib_{}'.format(tool))
             except AttributeError:
                 # OK, that didn't work so well...
-                logger.error('Unsupported ECAD tool library: {}.'.format(tool))
-                raise Exception
+                raise ValueError('Unsupported ECAD tool library: {}.'.format(tool))
             else:
                 load_func(filename, skidl.lib_search_paths[tool])
                 self.filename = filename
@@ -167,11 +166,9 @@ class SchLib(object):
 
             # No part with that alias either, so signal an error.
             if not parts:
-                if not silent:
-                    logger.error(
-                        'Unable to find part {} in library {}.'.format(
-                            name, getattr(self, 'filename', 'UNKNOWN')))
-                raise Exception
+                raise ValueError(
+                    'Unable to find part {} in library {}.'.format(
+                        name, getattr(self, 'filename', 'UNKNOWN')))
 
         # Multiple parts with that name or alias exists, so return the list
         # of parts or just the first part on the list.

--- a/skidl/py_2_3.py
+++ b/skidl/py_2_3.py
@@ -37,7 +37,6 @@ USING_PYTHON2 = (sys.version_info.major == 2)
 USING_PYTHON3 = not USING_PYTHON2
 
 if USING_PYTHON2:
-
     class FileNotFoundError(OSError):
         pass
 

--- a/skidl/skidl.py
+++ b/skidl/skidl.py
@@ -28,8 +28,6 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import open
-from future import standard_library
-standard_library.install_aliases()
 
 from .py_2_3 import *  # pylint: disable=wildcard-import
 from .defines import *

--- a/skidl/tools/kicad.py
+++ b/skidl/tools/kicad.py
@@ -67,8 +67,8 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
     # doesn't open, then try looking in the KiCad library directory.
     try:
         f, _ = find_and_open_file(filename, lib_search_paths_, lib_suffixes[KICAD])
-    except Exception as e:
-        raise Exception(
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
             'Unable to open KiCad Schematic Library File {} ({})'.format(
                 filename, str(e)))
 
@@ -76,7 +76,7 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
     header = []
     header = [f.readline()]
     if header and 'EESchema-LIBRARY' not in header[0]:
-        raise Exception(
+        raise RuntimeError(
             'The file {} is not a KiCad Schematic Library File.\n'.format(
                 filename))
 

--- a/skidl/tools/kicad.py
+++ b/skidl/tools/kicad.py
@@ -36,8 +36,6 @@ from builtins import int
 from builtins import range
 from builtins import dict
 from builtins import zip
-from future import standard_library
-standard_library.install_aliases()
 
 import os.path
 import time

--- a/skidl/tools/skidl.py
+++ b/skidl/tools/skidl.py
@@ -32,8 +32,8 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import str
-from future import standard_library
-standard_library.install_aliases()
+
+from ..py_2_3 import *  # pylint: disable=wildcard-import
 
 from ..defines import SKIDL
 

--- a/skidl/tools/skidl.py
+++ b/skidl/tools/skidl.py
@@ -56,8 +56,8 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
 
     try:
         f, _ = find_and_open_file(filename, lib_search_paths_, lib_suffixes[SKIDL])
-    except Exception as e:
-        raise Exception(
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
             'Unable to open SKiDL Schematic Library File {} ({})'.format(
                 filename, str(e)))
     try:
@@ -74,7 +74,7 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
                 return
 
         # Oops! No library object. Something went wrong.
-        raise Exception('No SchLib object found in {}'.format(filename))
+        raise ValueError('No SchLib object found in {}'.format(filename))
 
     except Exception as e:
         logger.error('Problem with {}'.format(f))

--- a/skidl/tools/spice.py
+++ b/skidl/tools/spice.py
@@ -35,8 +35,6 @@ from builtins import int
 from builtins import range
 from builtins import dict
 from builtins import zip
-from future import standard_library
-standard_library.install_aliases()
 
 import os.path
 from ..py_2_3 import *

--- a/skidl/tools/spice.py
+++ b/skidl/tools/spice.py
@@ -80,8 +80,8 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
             allow_failure=False,
             exclude_binary=True,
             descend=-1)
-    except Exception as e:
-        raise Exception('Unable to open SPICE Library File {} ({})'.format(
+    except FileNotFoundError as e:
+        raise FileNotFoundError('Unable to open SPICE Library File {} ({})'.format(
             filename, str(e)))
 
     # Read the definition of each part line-by-line and then create

--- a/skidl/utilities.py
+++ b/skidl/utilities.py
@@ -38,8 +38,6 @@ from builtins import str
 from builtins import zip
 from builtins import range
 from builtins import object
-from future import standard_library
-standard_library.install_aliases()
 
 import sys
 import os

--- a/skidl/utilities.py
+++ b/skidl/utilities.py
@@ -574,7 +574,7 @@ def expand_indices(slice_min, slice_max, *indices):
                 # added to the list.
                 ids.extend(explode(id.strip()))
         else:
-            raise ValueError('Unknown type in index: {}.'.format(type(indx)))
+            raise TypeError('Unknown type in index: {}.'.format(type(indx)))
 
     # Return the completely expanded list of indices.
     return ids

--- a/skidl/utilities.py
+++ b/skidl/utilities.py
@@ -262,8 +262,7 @@ def find_and_open_file(filename,
     if allow_failure:
         return None, None
     else:
-        logger.error("Can't open file: {}.\n".format(filename))
-        raise FileNotFoundError
+        raise FileNotFoundError("Can't open file: {}.\n".format(filename))
 
 
 def add_unique_attr(obj, name, value):
@@ -545,9 +544,8 @@ def expand_indices(slice_min, slice_max, *indices):
         # Do this if it's a downward slice (e.g., [7:0]).
         if start > stop:
             if slc.start and slc.start > slice_max:
-                logger.error('Index out of range ({} > {})!'.format(
+                raise IndexError('Index out of range ({} > {})!'.format(
                     slc.start, slice_max))
-                raise Exception
             # Count down from start to stop.
             stop = stop - step
             step = -step
@@ -555,9 +553,8 @@ def expand_indices(slice_min, slice_max, *indices):
         # Do this if it's a normal (i.e., upward) slice (e.g., [0:7]).
         else:
             if slc.stop and slc.stop > slice_max:
-                logger.error('Index out of range ({} > {})!'.format(
+                raise IndexError('Index out of range ({} > {})!'.format(
                     slc.stop, slice_max))
-                raise Exception
             # Count up from start to stop
             stop += step
 
@@ -579,8 +576,7 @@ def expand_indices(slice_min, slice_max, *indices):
                 # added to the list.
                 ids.extend(explode(id.strip()))
         else:
-            logger.error('Unknown type in index: {}.'.format(type(indx)))
-            raise Exception
+            raise ValueError('Unknown type in index: {}.'.format(type(indx)))
 
     # Return the completely expanded list of indices.
     return ids
@@ -642,13 +638,11 @@ def find_num_copies(**attribs):
 
     num_copies = list(num_copies)
     if len(num_copies) > 2:
-        logger.error(
+        raise ValueError(
             "Mismatched lengths of attributes: {}!".format(num_copies))
-        raise Exception
     elif len(num_copies) > 1 and min(num_copies) > 1:
-        logger.error(
+        raise ValueError(
             "Mismatched lengths of attributes: {}!".format(num_copies))
-        raise Exception
 
     try:
         return max(num_copies)

--- a/skidl/utilities.py
+++ b/skidl/utilities.py
@@ -260,7 +260,7 @@ def find_and_open_file(filename,
     if allow_failure:
         return None, None
     else:
-        raise FileNotFoundError("Can't open file: {}.\n".format(filename))
+        log_and_raise(logger, FileNotFoundError, "Can't open file: {}.\n".format(filename))
 
 
 def add_unique_attr(obj, name, value):
@@ -542,7 +542,7 @@ def expand_indices(slice_min, slice_max, *indices):
         # Do this if it's a downward slice (e.g., [7:0]).
         if start > stop:
             if slc.start and slc.start > slice_max:
-                raise IndexError('Index out of range ({} > {})!'.format(
+                log_and_raise(logger, IndexError, 'Index out of range ({} > {})!'.format(
                     slc.start, slice_max))
             # Count down from start to stop.
             stop = stop - step
@@ -551,7 +551,7 @@ def expand_indices(slice_min, slice_max, *indices):
         # Do this if it's a normal (i.e., upward) slice (e.g., [0:7]).
         else:
             if slc.stop and slc.stop > slice_max:
-                raise IndexError('Index out of range ({} > {})!'.format(
+                log_and_raise(logger, IndexError, 'Index out of range ({} > {})!'.format(
                     slc.stop, slice_max))
             # Count up from start to stop
             stop += step
@@ -574,7 +574,8 @@ def expand_indices(slice_min, slice_max, *indices):
                 # added to the list.
                 ids.extend(explode(id.strip()))
         else:
-            raise TypeError('Unknown type in index: {}.'.format(type(indx)))
+            log_and_raise(logger, TypeError,
+                          'Unknown type in index: {}.'.format(type(indx)))
 
     # Return the completely expanded list of indices.
     return ids
@@ -636,10 +637,10 @@ def find_num_copies(**attribs):
 
     num_copies = list(num_copies)
     if len(num_copies) > 2:
-        raise ValueError(
+        log_and_raise(logger, ValueError,
             "Mismatched lengths of attributes: {}!".format(num_copies))
     elif len(num_copies) > 1 and min(num_copies) > 1:
-        raise ValueError(
+        log_and_raise(logger, ValueError,
             "Mismatched lengths of attributes: {}!".format(num_copies))
 
     try:
@@ -722,3 +723,8 @@ def add_to_function_list(class_or_inst, list_name, func):
 def add_erc_function(class_or_inst, func):
     """Add an ERC function to a class or class instance."""
     add_to_function_list(class_or_inst, 'erc_list', func)
+
+
+def log_and_raise(logger_in, exc_class, message):
+    logger_in.error(message)
+    raise exc_class(message)

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -13,7 +13,7 @@ def test_alias_2():
     vreg = Part('xess.lib', '1117')
     vreg.set_pin_alias('my_alias', 1)
     vreg.set_pin_alias('my_alias', 2)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         vreg.set_pin_alias('new_alias', 'my_alias')
 
 def test_alias_3():
@@ -22,5 +22,5 @@ def test_alias_3():
     vreg[2].aliases = 'my_alias'
     assert len(vreg['my_alias']) == 2
     assert len(vreg['.*']) == 4
-    with pytest.raises(Exception):
+    with pytest.raises(NotImplementedError):
         vreg['my_alias'].aliases = 'new_alias'

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -128,14 +128,14 @@ def test_bus_11():
 
 def test_bus_12():
     bus1 = Bus('A', 8)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         bus1[5:0] = 6 * Pin()
 
 
 def test_bus_13():
     bus1 = Bus('A', 8)
     bus1 += 8 * Pin()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         bus1[5:0] = 6 * Pin()
 
 def test_bus_14():

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -115,27 +115,27 @@ def test_bus_9():
 def test_bus_10():
     bus1 = Bus('A', 8)
     bus2 = Bus('B', 9)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         bus1 += bus2
 
 
 def test_bus_11():
     bus1 = Bus('A', 8)
     bus2 = Bus('B', 9)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         bus2 += bus1
 
 
 def test_bus_12():
     bus1 = Bus('A', 8)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         bus1[5:0] = 6 * Pin()
 
 
 def test_bus_13():
     bus1 = Bus('A', 8)
     bus1 += 8 * Pin()
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         bus1[5:0] = 6 * Pin()
 
 def test_bus_14():

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -142,7 +142,7 @@ def test_connect_9():
 def test_connect_10():
     n1 = Net()
     p1, p2, p3 = 3 * Pin()
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n1[1] += p1, p2, p3
 
 def test_connect_11():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,5 +1,6 @@
 import pytest
 from skidl import *
+from skidl.py_2_3 import *  # pylint: disable=wildcard-import
 from .setup_teardown import *
 
 def test_missing_lib():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -6,9 +6,9 @@ def test_missing_lib():
     # Sometimes, loading a part from a non-existent library doesn't throw an
     # exception until the second time it's tried. This detects that error.
     set_query_backup_lib(False)  # Don't allow searching backup lib that might exist from previous tests.
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         a = Part('crap', 'R')
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         b = Part('crap', 'C')
 
 def test_lib_import_1():
@@ -81,10 +81,10 @@ def test_lib_1():
 
 def test_non_existing_lib_cannot_be_loaded():
     for tool in ALL_TOOLS:
-        with pytest.raises(Exception):
+        with pytest.raises(FileNotFoundError):
             lib = SchLib("non-existing", tool = tool)
 
 def test_part_from_non_existing_lib_cannot_be_instantiated():
     for tool in ALL_TOOLS:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             part = Part("non-existing", "P", tool = tool)

--- a/tests/test_make_parts.py
+++ b/tests/test_make_parts.py
@@ -158,7 +158,7 @@ def test_circuit_add_rmv_1():
     assert len(circuit1.nets) == 1 # Add 1 for NC
     assert len(circuit2.nets) == 2 # Add 1 for NC
     n1 += r1[1]
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         circuit1 += r1
 
 def test_circuit_add_rmv_2():
@@ -182,5 +182,5 @@ def test_circuit_connect_btwn_circuits_1():
     n1 = Net('N1')
     circuit1 += r1
     circuit2 += n1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n1 += r1[1]

--- a/tests/test_multi_circuits.py
+++ b/tests/test_multi_circuits.py
@@ -164,7 +164,7 @@ def test_circuit_add_rmv_1():
     assert len(circuit1.nets) == 1 # Add 1 for NC
     assert len(circuit2.nets) == 2 # Add 1 for NC
     n1 += r1[1]
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         circuit1 += r1
 
 def test_circuit_add_rmv_2():
@@ -199,7 +199,7 @@ def test_circuit_connect_btwn_circuits_1():
     n1 = Net('N1')
     circuit1 += r1
     circuit2 += n1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n1 += r1[1]
 
 def test_circuit_NC_1():

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -48,14 +48,14 @@ def test_netclass_2():
     n1 = Net()
     n1 += vreg[1,2,3]
     n1.netclass = NetClass('my_net', a=1, b=2, c=3)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n1.netclass = NetClass('my_net', a=5, b=6, c=7)
 
 def test_netclass_3():
     n1, n2 = Net('a'), Net('b')
     n1.netclass = NetClass('class1')
     n2.netclass = NetClass('class2')
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n1 += n2
 
 def test_netclass_4():
@@ -63,7 +63,7 @@ def test_netclass_4():
     n1 += n2
     n1.netclass = NetClass('class1')
     assert(n2.netclass.name == 'class1')
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         n2.netclass = NetClass('class2')
 
 def test_drive_1():
@@ -82,4 +82,3 @@ def test_drive_2():
     assert(n2.drive == 5)
     n1.drive = 7
     assert(n2.drive == 7)
-    

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -46,14 +46,14 @@ def test_ntwk_3():
 def test_ntwk_4():
     """Test limit on network length."""
     q1 = Part('device', 'Q_NPN_EBC')
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         Network(q1)
 
 
 def test_ntwk_5():
     """Test limit on network length."""
     q1 = Part('device', 'Q_NPN_EBC')
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         Network(q1[:])
 
 
@@ -61,5 +61,5 @@ def test_ntwk_6():
     """Test limit on network length."""
     r1, r2 = Part('device', 'R', dest=TEMPLATE) * 2
     q1 = Part('device', 'Q_NPN_EBC')
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         (r1 | r2) & q1

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -16,7 +16,7 @@ def test_lib_import_1():
         print(p)
 
 def test_lib_import_2():
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         lib = SchLib('lt1074', tool=SPICE)
 
 def test_lib_export_1():

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -4,6 +4,7 @@ import pytest
 pexpect = pytest.importorskip("PySpice")
 
 from skidl.pyspice import *
+from skidl.py_2_3 import *  # pylint: disable=wildcard-import
 from .setup_teardown import *
 import PySpice
 


### PR DESCRIPTION
I've changed all instances of

```python
logger.error('message')
raise Exception
```

to

```python
raise MoreSpecificExceptionType('message')
```

This serves two purposes:

- error handling is easier, since it's possible to catch only one type of exception, instead of having to catch all exceptions
- it's more idiomatic. I've never seen the other style before, and I've been working with python for a while.

It's also backwards compatible. Any client code that was catching `Exception` will still catch the new exceptions as they all inherit from `Exception`.