### PR TITLE
Auto-format code 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv
 # Packages
 *.egg
 *.egg-info
+pip-wheel-metadata/
 dist
 build
 eggs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# IntelliJ IDEA & pycharm
+.idea
+
+# virtualenvs
+venv
+
 *.py[cod]
 *.bak
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,21 @@ matrix:
     - python: 2.7
       name: "Test Python 2.7"
       env: TOXENV=py27
+      install: pip install tox
+      script: tox
     - python: 3.6
       name: "Test Python 3.6"
       env: TOXENV=py36
+      install: pip install tox
+      script: tox
     - python: 3.7
       name: "Test Python 3.7"
       env: TOXENV=py37
+      install: pip install tox
+      script: tox
     - python: 3.6
       name: "Check formatting"
       install: pip install black isort
       script:
         - black --check --diff skidl tests setup.py
         - isort --check --diff --recursive tests skidl setup.py
-
-install: pip install tox
-script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
+dist: xenial
 language: python
 matrix:
   include:
     - python: 2.7
+      name: "Test Python 2.7"
       env: TOXENV=py27
     - python: 3.6
+      name: "Test Python 3.6"
       env: TOXENV=py36
-install:
-  - pip install tox
-script:
-  - tox
+    - python: 3.7
+      name: "Test Python 3.7"
+      env: TOXENV=py37
+    - python: 3.6
+      name: "Check formatting"
+      install: pip install black isort
+      script:
+        - black --check --diff skidl tests setup.py
+        - isort --check --diff --recursive tests skidl setup.py
+
+install: pip install tox
+script: tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -74,13 +74,14 @@ Ready to contribute? Here's how to set up `skidl` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. When you're done making changes, auto-format your code and check that your changes pass the tests, including testing other Python versions with tox::
 
-    $ flake8 skidl tests
+    $ isort -y --recursive tests skidl setup.py
+    $ black skidl tests setup.py
     $ python setup.py test
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get isort, black, and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.black]
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | /skidl/libs/
+)
+'''
+
+[tool.isort]
+multi_line_output=3
+include_trailing_comma=true
+force_grid_wrap=0
+use_parentheses=true
+line_length=88
+known_first_party=["skidl"]
+known_future_library=["skidl.py_2_3"]
+known_third_party=["pytest", "PySpice"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-    
+
 import sys
 import setuptools
 
@@ -12,7 +12,7 @@ __email__ = 'info@xess.com'
 if 'sdist' in sys.argv[1:]:
     with open('skidl/pckg_info.py','w') as f:
         for name in ['__version__','__author__','__email__']:
-            f.write("{} = '{}'\n".format(name,locals()[name]))
+            f.write('{} = "{}"\n'.format(name,locals()[name]))
 
 try:
     from setuptools import setup

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -3,9 +3,10 @@ import pytest
 # Skip this test module if PySpice is missing.
 pexpect = pytest.importorskip("PySpice")
 
-from skidl.pyspice import *
+from skidl.py_2_3 import *  # pylint: disable=wildcard-import
 from .setup_teardown import *
-import PySpice
+
+from skidl.pyspice import *  # isort:skip
 
 
 def test_lib_import_1():

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py27, py37, local_py27, local_py37
+envlist = py{27,36,37}, local_py{27,36,37}
 
 [travis]
 python =
 	2.7: py27
+    3.6: py36
 	3.7: py37
 
 [testenv]
@@ -13,25 +14,16 @@ setenv =
 deps =
     pytest
     kinparse >= 0.1.0
-
-[testenv:py27]
 changedir = tests
 commands =
-    pip install -e {toxinidir}
-	py.test
-
-[testenv:py37]
-changedir = tests
-commands =
-    pip install -e {toxinidir}
-	py.test
+    py{27,36,37}: pip install -e {toxinidir}
+    py.test
 
 [testenv:local_py27]
 basepython = C:\Python27-32\python.exe
-changedir = tests
-commands = py.test
+
+[testenv:local_py36]
+basepython = C:\Python36-64\python.exe
 
 [testenv:local_py37]
 basepython = C:\Python37-64\python.exe
-changedir = tests
-commands = py.test


### PR DESCRIPTION
(this change is based upon https://github.com/xesscorp/skidl/pull/49. If you don't want that PR, I'd be happy to rebase it)

This change automatically formats the code. In my opinion, this is better than using something like flake8, since it doesn't require any manual changes--whatever the output of the tool is, is the correct formatting. It reduces the mental overhead (for me, at least), by not having to consider code formatting while writing the code and allowing the tool to figure out the right way to do it.

I've updated the `CONTRIBUTING.rst` in order to show the procedure for auto-formatting.

I've also updated the Travis CI file to automatically check formatting.