### PR TITLE
fix: not all connections are plotted

### DIFF
--- a/skidl/Circuit.py
+++ b/skidl/Circuit.py
@@ -604,7 +604,7 @@ class Circuit(SkidlBaseObject):
             if n.name not in split_nets:
                 dot.node(n.name, shape=net_shape, xlabel=xlabel)
 
-            for j, pin in enumerate(n.pins):
+            for j, pin in enumerate(n.get_pins()):
                 net_ref = n.name
                 pin_part_ref = pin.part.ref
 


### PR DESCRIPTION
For the example [Making Parallel and Serial Networks](https://xesscorp.github.io/skidl/docs/_site/#making-parallel-and-serial-networks) from the skidl documentation the generate_graph function was broken.
The example
```
from skidl import *

vcc, gnd = Net('VCC'), Net('GND')
r1, r2, r3, r4 = Part('device', 'R', dest=TEMPLATE) * 4
par_ntwk = vcc & (r1 | r2 | r3 | r4) & gnd

dot = generate_graph()
dot.render("par_ntwk", format="svg")
```
results in the image below before this pull request
![par_ntwk_before](https://user-images.githubusercontent.com/4752766/60034740-967f2600-96ab-11e9-8a02-550c760074b4.png)

and after
![par_ntwk_after](https://user-images.githubusercontent.com/4752766/60034783-9aab4380-96ab-11e9-9ee4-0a221801ddf9.png)
