### PR TITLE
Add wxPython build dependencies to CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ matrix:
       before_install:
         # Install neccessary Linux dependencies to build wxPython.
         #   See: https://github.com/wxWidgets/Phoenix/blob/master/.azure/ci-linux-job.yml
-        - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
-        - sudo apt-get install -y build-essential
-        - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
       script:
         - tox
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install -y build-essential
         - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev \
-                libsdl2-dev libgstreamer-plugins-base1.0-dev libnotify-dev \
-                libsm-dev libwebkit2gtk-4.0-dev libxtst-dev \
-                libgl1-mesa-dev libglu1-mesa-dev
+                libgstreamer-plugins-base1.0-dev libnotify-dev \
+                libwebkit2gtk-4.0-dev libxtst-dev \
+                libglu1-mesa-dev
       script:
         - tox
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install -y build-essential
         - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev \
-                libgstreamer-plugins-base1.0-dev libnotify-dev \
-                libwebkit2gtk-4.0-dev libxtst-dev \
-                libglu1-mesa-dev
+                libnotify-dev libxtst-dev
       script:
         - tox
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ matrix:
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
         - sudo apt-get install -y build-essential
-        - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev \
-                libxtst-dev
+        - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
       script:
         - tox
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,20 @@ matrix:
     - python: 2.7
       name: "Test Python 2.7"
       env: TOXENV=py27
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y build-essential python-dev libgtk-3-dev libjpeg-dev libtiff-dev      
       install: pip install tox
-      script: tox
+      script: tox -vvvvv
     - python: 3.6
       name: "Test Python 3.6"
       env: TOXENV=py36
-      install: pip install tox
       before_install:
         # Install neccessary Linux dependencies to build wxPython.
         #   See: https://github.com/wxWidgets/Phoenix/blob/master/.azure/ci-linux-job.yml
         - sudo apt-get update
         - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+      install: pip install tox
       script:
         # Pass -vvv to pip through tox because wxPython can take ~20min to build and
         # Travis CI thinks that the build has stalled unless build progress is output.
@@ -23,8 +26,19 @@ matrix:
     - python: 3.7
       name: "Test Python 3.7"
       env: TOXENV=py37
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
       install: pip install tox
-      script: tox
+      script: tox -vvvvv
+    - python: 3.8
+      name: "Test Python 3.8"
+      env: TOXENV=py38
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+      install: pip install tox
+      script: tox -vvvvv
     - python: 3.6
       name: "Check formatting"
       install: pip install black isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install -y build-essential
         - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev \
-                libnotify-dev libxtst-dev
+                libxtst-dev
       script:
         - tox
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
       script:
-        - tox
+        # Pass -vvv to pip through tox because wxPython can take ~20min to build and
+        # Travis CI thinks that the build has stalled unless build progress is output.
+        - tox -vvvvv
     - python: 3.7
       name: "Test Python 3.7"
       env: TOXENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,18 @@ matrix:
       name: "Test Python 3.6"
       env: TOXENV=py36
       install: pip install tox
-      script: tox
+      before_install:
+        # Install neccessary Linux dependencies to build wxPython.
+        #   See: https://github.com/wxWidgets/Phoenix/blob/master/.azure/ci-linux-job.yml
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt-get update
+        - sudo apt-get install -y build-essential
+        - sudo apt-get install -y python3-dev libgtk-3-dev libjpeg-dev libtiff-dev \
+                libsdl2-dev libgstreamer-plugins-base1.0-dev libnotify-dev \
+                libsm-dev libwebkit2gtk-4.0-dev libxtst-dev \
+                libgl1-mesa-dev libglu1-mesa-dev
+      script:
+        - tox
     - python: 3.7
       name: "Test Python 3.7"
       env: TOXENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,16 @@ matrix:
       env: TOXENV=py27
       before_install:
         - sudo apt-get update
-        - sudo apt-get install -y build-essential python-dev libgtk-3-dev libjpeg-dev libtiff-dev      
+        - sudo apt-get install -y build-essential python-dev libgtk-3-dev      
       install: pip install tox
       script: tox -vvvvv
     - python: 3.6
       name: "Test Python 3.6"
       env: TOXENV=py36
       before_install:
-        # Install neccessary Linux dependencies to build wxPython.
-        #   See: https://github.com/wxWidgets/Phoenix/blob/master/.azure/ci-linux-job.yml
+        # Install neccessary Linux dependencies to build wxPython from source.
         - sudo apt-get update
-        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev
       install: pip install tox
       script:
         # Pass -vvv to pip through tox because wxPython can take ~20min to build and
@@ -28,7 +27,7 @@ matrix:
       env: TOXENV=py37
       before_install:
         - sudo apt-get update
-        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev
       install: pip install tox
       script: tox -vvvvv
     - python: 3.8
@@ -36,7 +35,7 @@ matrix:
       env: TOXENV=py38
       before_install:
         - sudo apt-get update
-        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev libjpeg-dev libtiff-dev
+        - sudo apt-get install -y build-essential python3-dev libgtk-3-dev
       install: pip install tox
       script: tox -vvvvv
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     test_suite="tests",
     tests_require=test_requirements,

--- a/skidl/Bus.py
+++ b/skidl/Bus.py
@@ -121,8 +121,8 @@ class Bus(SkidlBaseObject):
 
         # Add the bus to the circuit.
         self.circuit = (
-            None
-        )  # Bus won't get added if it's already seen as part of circuit.
+            None  # Bus won't get added if it's already seen as part of circuit.
+        )
         attribs[
             "circuit"
         ] += self  # Add bus to circuit. This also sets self.circuit again.

--- a/skidl/Part.py
+++ b/skidl/Part.py
@@ -113,8 +113,8 @@ class Part(SkidlBaseObject):
         self.unit = {}  # Dictionary for storing subunits of the part, if desired.
         self.pins = []  # Start with no pins, but a place to store them.
         self.name = (
-            name
-        )  # Assign initial part name. (Must come after circuit is assigned.)
+            name  # Assign initial part name. (Must come after circuit is assigned.)
+        )
         self.description = ""  # Make sure there is a description, even if empty.
         self._ref = ""  # Provide a member for holding a reference.
         self.ref_prefix = ""  # Provide a member for holding the part reference prefix.

--- a/skidl/search_gui/skidl_footprint_search.py
+++ b/skidl/search_gui/skidl_footprint_search.py
@@ -33,7 +33,6 @@ import string
 
 import pykicad.module as pym
 import wx
-
 from skidl import (
     KICAD,
     footprint_search_paths,

--- a/skidl/search_gui/skidl_part_footprint_search.py
+++ b/skidl/search_gui/skidl_part_footprint_search.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 import os
 
 import wx
-
 from skidl import (
     KICAD,
     SchLib,

--- a/skidl/search_gui/skidl_part_search.py
+++ b/skidl/search_gui/skidl_part_search.py
@@ -32,7 +32,6 @@ import collections
 import os
 
 import wx
-
 from skidl import (
     KICAD,
     lib_search_paths,


### PR DESCRIPTION
Attempt to fix CI failures.

Attempting to use wxPython's CI config to help:
- https://github.com/wxWidgets/Phoenix/blob/master/.azure/ci-linux-job.yml#L32

Wheels are not available for Linux, so build dependencies are required.

- PR also adds Python 3.8 support.
- PR fixes `black` and `isort` errors