### PR TITLE
xspice: allow null pins for no-connect

### DIFF
--- a/skidl/tools/spice.py
+++ b/skidl/tools/spice.py
@@ -402,7 +402,11 @@ def add_xspice_to_circuit(part, circuit):
     for pin in part.pins:
         if isinstance(pin, Pin):
             # Add a non-vector pin.
-            args.append(node(pin))
+            # permit no-connect pins
+            if pin.name.lower() == "null":
+                args.append("NULL")
+            else:
+                args.append(node(pin))
         elif isinstance(pin, PinList):
             # Add pins from a pin vector.
             args.append("[" + " ".join([node(p) for p in pin]) + "]")


### PR DESCRIPTION
This PR permits no-connect pins for xspice models. This is described in 12.1.1 of v31 manual (p155 for me). There's an example in 27.2.1 (Circuit example C3).