### PR TITLE
Expose __file__ to SKiDL libraries on import

### DIFF
--- a/skidl/tools/skidl.py
+++ b/skidl/tools/skidl.py
@@ -52,7 +52,7 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
     from ..utilities import find_and_open_file
 
     try:
-        f, _ = find_and_open_file(filename, lib_search_paths_, lib_suffixes[SKIDL])
+        f, path = find_and_open_file(filename, lib_search_paths_, lib_suffixes[SKIDL])
     except FileNotFoundError as e:
         raise FileNotFoundError(
             "Unable to open SKiDL Schematic Library File {} ({})".format(
@@ -62,7 +62,9 @@ def _load_sch_lib_(self, filename=None, lib_search_paths_=None):
     try:
         # The SKiDL library is stored as a Python module that's executed to
         # recreate the library object.
-        vars_ = {}  # Empty dictionary for storing library object.
+        vars_ = {
+            '__file__': path,
+        }
         exec(f.read(), vars_)  # Execute and store library in dict.
 
         # Now look through the dict to find the library object.


### PR DESCRIPTION
I have a few libraries with components dynamically created from CSV files stored along side the library scripts. In order to make reading this data more portable I'd like to derive a relative path using the __file__ variable. This diff exposes that variable to SKiDL libraries when imported.