### PR TITLE
Feature: Add optional fixed hierarchical part naming in netlists

### DIFF
--- a/skidl/tools/kicad.py
+++ b/skidl/tools/kicad.py
@@ -33,7 +33,6 @@ import re
 import time
 from builtins import dict, int, range, str, zip
 from collections import namedtuple
-from random import randint
 
 from future import standard_library
 
@@ -650,12 +649,7 @@ def _gen_netlist_comp_(self):
 
     # Embed the hierarchy along with a random integer into the sheetpath for each component.
     # This enables hierarchical selection in pcbnew.
-    hierarchy = add_quotes(
-        "/"
-        + getattr(self, "hierarchy", ".").replace(".", "/")
-        + "/"
-        + str(randint(0, 2 ** 64 - 1))
-    )
+    hierarchy = add_quotes("/" + self.hierarchical_name.replace(".", "/"))
     tstamps = hierarchy
 
     fields = ""
@@ -774,7 +768,7 @@ def _gen_xml_net_(self):
 def _gen_svg_comp_(self, symtx, net_stubs=None):
     """
     Generate SVG for this component.
-    
+
     Args:
         self: Part object for which an SVG symbol will be created.
         net_stubs: List of Net objects whose names will be connected to

--- a/tests/test_hierarchical_names.py
+++ b/tests/test_hierarchical_names.py
@@ -1,0 +1,72 @@
+import pytest
+
+from skidl import *
+
+from .setup_teardown import *
+
+
+class Resistor(Part):
+    def __init__(self, value, ref=None, footprint="Resistors_SMD:R_0805", **kwargs):
+        super().__init__(
+            "Device", "R", value=value, ref=ref, footprint=footprint, **kwargs
+        )
+
+
+def test_hierarchical_names_1():
+    r1s = []
+    r2s = []
+
+    @subcircuit
+    def resdiv():
+        gnd = Net("GND")  # Ground reference.
+        vin = Net("VI")  # Input voltage to the divider.
+        vout = Net("VO")  # Output voltage from the divider.
+
+        r1 = Resistor("1k")
+        r1.tag = "resistor1"
+        r1s.append(r1)
+        r2 = Resistor("500", tag="resistor2")
+        r2s.append(r2)
+
+        r1[1] += vin  # Connect the input to the first resistor.
+        r2[2] += gnd  # Connect the second resistor to ground.
+        vout += r1[2], r2[1]  # Output comes from the connection of the two resistors.
+
+    resdiv()
+    resdiv(tag="divider1")
+
+    assert len(default_circuit.parts) == 4
+    assert len(default_circuit.get_nets()) == 6
+
+    assert r1s[0].hierarchical_name == "top.resdiv0.resistor1"
+    assert r1s[1].hierarchical_name == "top.resdivdivider1.resistor1"
+    assert r2s[0].hierarchical_name == "top.resdiv0.resistor2"
+    assert r2s[1].hierarchical_name == "top.resdivdivider1.resistor2"
+
+    ERC()
+    generate_netlist()
+    generate_xml()
+
+
+def test_hierarchical_names_2():
+    @subcircuit
+    def circuit_for_test():
+        pass
+
+    circuit_for_test(tag="1")
+    try:
+        circuit_for_test(tag="1")
+        assert False, "subcircuit should throw with duplicate hierarchical name"
+    except Exception:
+        pass
+
+
+def test_hierarchical_names_3():
+    r1 = Resistor("1k")
+    r1.tag = "resistor1"
+
+    try:
+        r1 = Resistor("1k", tag="resistor1")
+        assert False, "part should throw with duplicate hierarchical name"
+    except Exception:
+        pass


### PR DESCRIPTION
Kicad's `pcbnew` offers two ways of matching imported netlists to existing footprints in a project (when reimporting the netlist).  By the reference name, or by the `tstamps` field in the netlist.  The default is to use the tstamps field, and this is the preferable way to tie the footprints to the netlist components when the netlist is exported from eeschema since eeschema keeps the tstamps field fixed for a given component.  Prior to this change skidl would populate the tstamps field with a random number.  This meant reimporting a netlist (using default settings) would replace all components, causing you to lose any prior layout work.  Reimporting while tieing components to footprints using reference identifiers is not much better since reference identifiers are assigned in program order, meaning that inserting a component anywhere in your design will offset your references names for the rest of the design.  This could be worked around by always specifying a reference identifier in skidl, but it still causes issues in the presence of subcircuits and pacakages unless you build hierarchical reference names manually (which also end up looking ugly on your PCB silk screen if you want to show them).

This PR changes how tstamps are emitted.  Instead of using a randomly generated identifier at netlist generation time, Parts are assigned an identifier (by default random, but also user assignable) at part creation time.  Similarly the hierarchical name building done in subcircuits is extended to allow the identifier to be user specifiable (currently it is just an incrementing int based on the subcircuit name).  I commandeered the `identifier` parameter to any subcircuit or package in order to implement this, which potentially breaks existing designs using it.

With this PR any design that specifies identifiers for all components, subcircuits and packages can easily be iterated on while performing the PCB layout without losing work.

I currently have this change based on master, but am happy to rebase it onto development if that is helpful.