### PR TITLE
Update kicad.py

### DIFF
--- a/skidl/tools/kicad.py
+++ b/skidl/tools/kicad.py
@@ -831,7 +831,7 @@ def _parse_lib_part_kicad_v6(self, get_name_only):
         "power_out": Pin.types.PWROUT,
         "open_collector": Pin.types.OPENCOLL,
         "open_emitter": Pin.types.OPENEMIT,
-        "unconnected": Pin.types.NOCONNECT,
+        "no_connect": Pin.types.NOCONNECT,
     }
 
     # Find all the units within a symbol. Skip the first item which is the


### PR DESCRIPTION
Fix "KeyError: 'no_connect'"

"no_connect" should be used, rather than "unconnected", in kicad_sym files.

See sym files here: https://gitlab.com/kicad/libraries/kicad-symbols (looks like this change is 4 months old now).