### PR TITLE
Workaround for issue 230, gen_svg failures.

### DIFF
--- a/src/skidl/tools/kicad6/gen_svg.py
+++ b/src/skidl/tools/kicad6/gen_svg.py
@@ -277,9 +277,12 @@ def draw_cmd_to_svg(draw_cmd, tx, part, net_stubs, max_stub_len):
                 )
             start = Point(*shape["at"][0:2])
             rotation = shape["at"][2]
-            justify = (
-                shape["effects"].get("justify", shape.get("justify", "left")).lower()
-            )
+            try:
+                justify = (
+                    shape["effects"].get("justify", shape.get("justify", "left")).lower()
+                )
+            except AttributeError:
+                justify = "left"
             dir = {"right": Point(-1, 0), "left": Point(1, 0)}[justify] * Tx().rot(
                 rotation
             )

--- a/src/skidl/tools/kicad7/gen_svg.py
+++ b/src/skidl/tools/kicad7/gen_svg.py
@@ -277,9 +277,12 @@ def draw_cmd_to_svg(draw_cmd, tx, part, net_stubs, max_stub_len):
                 )
             start = Point(*shape["at"][0:2])
             rotation = shape["at"][2]
-            justify = (
-                shape["effects"].get("justify", shape.get("justify", "left")).lower()
-            )
+            try:
+                justify = (
+                    shape["effects"].get("justify", shape.get("justify", "left")).lower()
+                )
+            except AttributeError:
+                justify = "left"
             dir = {"right": Point(-1, 0), "left": Point(1, 0)}[justify] * Tx().rot(
                 rotation
             )

--- a/src/skidl/tools/kicad8/gen_svg.py
+++ b/src/skidl/tools/kicad8/gen_svg.py
@@ -277,9 +277,12 @@ def draw_cmd_to_svg(draw_cmd, tx, part, net_stubs, max_stub_len):
                 )
             start = Point(*shape["at"][0:2])
             rotation = shape["at"][2]
-            justify = (
-                shape["effects"].get("justify", shape.get("justify", "left")).lower()
-            )
+            try:
+                justify = (
+                    shape["effects"].get("justify", shape.get("justify", "left")).lower()
+                )
+            except AttributeError:
+                justify = "left"
             dir = {"right": Point(-1, 0), "left": Point(1, 0)}[justify] * Tx().rot(
                 rotation
             )

--- a/src/skidl/tools/kicad9/gen_svg.py
+++ b/src/skidl/tools/kicad9/gen_svg.py
@@ -277,9 +277,12 @@ def draw_cmd_to_svg(draw_cmd, tx, part, net_stubs, max_stub_len):
                 )
             start = Point(*shape["at"][0:2])
             rotation = shape["at"][2]
-            justify = (
-                shape["effects"].get("justify", shape.get("justify", "left")).lower()
-            )
+            try:
+                justify = (
+                    shape["effects"].get("justify", shape.get("justify", "left")).lower()
+                )
+            except AttributeError:
+                justify = "left"
             dir = {"right": Point(-1, 0), "left": Point(1, 0)}[justify] * Tx().rot(
                 rotation
             )


### PR DESCRIPTION
Fix for issue 230: https://github.com/devbisme/skidl/issues/230

The `"effects"` lookup appears to return a list type rather than a string for certain components. In my case it was for the kicad 9 component `'Raspberry_Pi_4'` (40-pin connector).

```
...skidl/tools/kicad9/gen_svg.py", line 281, in draw_cmd_to_svg
    shape["effects"].get("justify", shape.get("justify", "left")).lower()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'lower'
```

The fix places the dictionary lookup behind a try/catch block, settings the default 'left' on `AttributeError`.

Fix repeated for other kicads as applicable. Possibly not the best way to solve this (I'm no python expert), but it got me passed my issue.

Note: I skipped the formatting as running the formatter resulted in a significant amount of non-relevant changes.