### PR TITLE
Fix circular import in kicad{6,7,8,9}/lib.py that crashes on import

### DIFF
--- a/src/skidl/tools/kicad6/lib.py
+++ b/src/skidl/tools/kicad6/lib.py
@@ -34,9 +34,7 @@ lib_suffix = [".kicad_sym"]
 @export_to_all
 def default_lib_paths():
     """Return default list of directories to search for part libraries."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     # Start search for part libraries in the current directory.
     paths = ["."]
@@ -55,9 +53,7 @@ def default_lib_paths():
 @export_to_all
 def get_fp_lib_tbl_dir():
     """Get the path where the global fp-lib-table file is found."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     paths = (
         f"$HOME/.config/kicad/{kicad_version}.0",

--- a/src/skidl/tools/kicad7/lib.py
+++ b/src/skidl/tools/kicad7/lib.py
@@ -34,9 +34,7 @@ lib_suffix = [".kicad_sym"]
 @export_to_all
 def default_lib_paths():
     """Return default list of directories to search for part libraries."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     # Start search for part libraries in the current directory.
     paths = ["."]
@@ -55,9 +53,7 @@ def default_lib_paths():
 @export_to_all
 def get_fp_lib_tbl_dir():
     """Get the path where the global fp-lib-table file is found."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     paths = (
         f"$HOME/.config/kicad/{kicad_version}.0",

--- a/src/skidl/tools/kicad8/lib.py
+++ b/src/skidl/tools/kicad8/lib.py
@@ -34,9 +34,7 @@ lib_suffix = [".kicad_sym"]
 @export_to_all
 def default_lib_paths():
     """Return default list of directories to search for part libraries."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     # Start search for part libraries in the current directory.
     paths = ["."]
@@ -55,9 +53,7 @@ def default_lib_paths():
 @export_to_all
 def get_fp_lib_tbl_dir():
     """Get the path where the global fp-lib-table file is found."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     paths = (
         f"$HOME/.config/kicad/{kicad_version}.0",

--- a/src/skidl/tools/kicad9/lib.py
+++ b/src/skidl/tools/kicad9/lib.py
@@ -34,9 +34,7 @@ lib_suffix = [".kicad_sym"]
 @export_to_all
 def default_lib_paths():
     """Return default list of directories to search for part libraries."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     # Start search for part libraries in the current directory.
     paths = ["."]
@@ -55,9 +53,7 @@ def default_lib_paths():
 @export_to_all
 def get_fp_lib_tbl_dir():
     """Get the path where the global fp-lib-table file is found."""
-    from skidl import get_default_tool
-
-    kicad_version = get_default_tool()[len("kicad"):]
+    kicad_version = __name__.split(".")[-2][len("kicad"):]
 
     paths = (
         f"$HOME/.config/kicad/{kicad_version}.0",


### PR DESCRIPTION
Fixes #287

During module initialization, SkidlConfig.__init__() calls default_lib_paths() and get_fp_lib_tbl_dir() on every tool module. These functions imported get_default_tool from skidl to determine the KiCad version number, but skidl hasn't finished initializing at that point, causing a circular ImportError on Python 3.12+.

Each tool module already knows its own version from its package name, so this just derives it locally from __name__ instead of importing back from skidl.

Tested on Python 3.12.10 and 3.14.3 on Windows 11 with KiCad 10.0.

Fixes 8 call sites across 4 files (2 functions each in kicad6-9).