### PR TITLE
fix(kicad9): emit power-symbol lib_symbols from placed instances (fixes EESCHEMA ? boxes)

### DIFF
--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -918,6 +918,26 @@ def _calc_sheet_tx(bbox):
 # ---------------------------------------------------------------------------
 
 
+def _power_lib_ids_in_elements(elements):
+    """Return the set of ``power:*`` lib_ids referenced by symbol instances in
+    ``elements``. Used to emit exactly the power-symbol definitions a sheet needs,
+    so every emitted power instance has a matching lib_symbols definition."""
+    found = set()
+    for el in elements:
+        if not (hasattr(el, "__getitem__") and len(el) and el[0] == "symbol"):
+            continue
+        for sub in el:
+            if (
+                hasattr(sub, "__getitem__")
+                and len(sub) >= 2
+                and sub[0] == "lib_id"
+                and isinstance(sub[1], str)
+                and sub[1].startswith("power:")
+            ):
+                found.add(sub[1])
+    return found
+
+
 @export_to_all
 def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
     """Convert a SchNode tree to S-expression schematic(s).
@@ -964,15 +984,11 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
             lib_id = f"{part.lib.filename}:{part.name}"
             lib_symbols[lib_id] = part
 
-    # Add power lib_symbols for any power symbols used in this sheet.
+    # Power-symbol definitions are emitted later from the instances actually
+    # placed on this sheet (see `_power_lib_ids_in_elements`), so no wire-based
+    # pre-scan is needed here. `pwr_symbols` is kept only to satisfy the
+    # flattened-node return contract.
     pwr_symbols = {}
-    for net in node.wires:
-        if net.name in pwr_symbol_names:
-            _used_power_symbols.add(net.name)
-    for pwr_name in _used_power_symbols:
-    # for pwr_name in sorted(_used_power_symbols):
-        pwr_lib_id = f"power:{pwr_name}"
-        pwr_symbols[pwr_lib_id] = pwr_name
 
     # Recurse into children.
     for i, child in enumerate(node.children.values()):
@@ -1038,10 +1054,16 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
     for part in lib_symbols.values():
         lib_symbols_sexp.append(Sexp(part_to_lib_symbol_definition(part)))
 
-    # Add S-expressions for any power symbols used in this sheet.
-    for id, pwr_name in pwr_symbols.items():
-        if id not in lib_symbols:
-            pwr_sexp = _extract_power_lib_symbol(pwr_name)
+    # Add power-symbol definitions. Derive these from the power-symbol INSTANCES
+    # actually emitted on this sheet (`elements`), NOT from `node.wires`: with
+    # auto_stub, power nets are stubbed (labels, not wires), so a wire-based scan
+    # misses them and the emitted instance has no definition -> KiCad reports an
+    # "unknown component". Scanning emitted instances guarantees every instance
+    # has a matching definition, and also covers power symbols contributed by
+    # flattened children (whose instances are already in `elements`).
+    for pwr_lib_id in sorted(_power_lib_ids_in_elements(elements)):
+        if pwr_lib_id not in lib_symbols:
+            pwr_sexp = _extract_power_lib_symbol(pwr_lib_id.split(":", 1)[1])
             if pwr_sexp:
                 lib_symbols_sexp.append(pwr_sexp)
 

--- a/tests/unit_tests/ai_tests/test_dev_base_fixes.py
+++ b/tests/unit_tests/ai_tests/test_dev_base_fixes.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+"""Regression tests for bugs in the `development` schematic backend, found while
+designing the snap backend split (see ARCHITECTURE-snap-backend-split.md).
+
+Bug 1 (missing symbols): power-symbol *definitions* were scoped per-sheet from
+`node.wires`, but power-symbol *instances* are emitted from power-net pins. With
+auto_stub, power nets are stubbed (labels, not wires), so instances were emitted
+on child sheets with no matching lib_symbols definition -> KiCad "unknown
+component".
+
+Bug 2 (label orientation): net-label angle must follow the pin's *rendered*
+direction (after the sheet Y-flip), not the abstract pin direction.
+"""
+
+import glob
+import os
+import re
+import shutil
+import tempfile
+
+import pytest
+from skidl import Circuit, Net, Part, Interface, subcircuit
+
+HAS_KICAD_LIBS = os.path.isdir(
+    os.getenv("KICAD9_SYMBOL_DIR", "/usr/share/kicad/symbols")
+)
+requires_kicad_libs = pytest.mark.skipif(
+    not HAS_KICAD_LIBS, reason="KiCad 9 symbol libraries not installed"
+)
+
+
+@pytest.fixture
+def output_dir():
+    d = tempfile.mkdtemp(prefix="skidl_dev_base_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _power_symbol_integrity(output_dir):
+    """Map {sheet_filename: [power lib_ids emitted as instances with no def]}."""
+    result = {}
+    for f in glob.glob(os.path.join(output_dir, "**", "*.kicad_sch"), recursive=True):
+        txt = open(f).read()
+        defined = set(re.findall(r'\(symbol\s+"([^"]+)"', txt))
+        instances = set(re.findall(r'\(lib_id\s+"([^"]+)"', txt))
+        missing = sorted(
+            i for i in instances if i.startswith("power:") and i not in defined
+        )
+        if missing:
+            result[os.path.basename(f)] = missing
+    return result
+
+
+def _build_two_stage_power_design(circuit):
+    """Two instances of a stage sharing VCC/GND power nets — hierarchical, so
+    each stage becomes its own sheet and the power nets get auto-stubbed."""
+    with circuit:
+
+        @subcircuit
+        def stage():
+            vcc, gnd, sig = Net("VCC"), Net("GND"), Net()
+            r1 = Part("Device", "R")
+            r2 = Part("Device", "R")
+            c1 = Part("Device", "C")
+            vcc & r1 & sig & r2 & gnd
+            sig & c1 & gnd
+            return Interface(vcc=vcc, gnd=gnd)
+
+        vcc, gnd = Net("VCC"), Net("GND")
+        s1 = stage()
+        s2 = stage()
+        s1.vcc += vcc
+        s2.vcc += vcc
+        s1.gnd += gnd
+        s2.gnd += gnd
+
+
+@requires_kicad_libs
+def test_power_symbol_defs_complete_under_autostub(output_dir):
+    """Every power-symbol instance must have a matching lib_symbols definition on
+    the same sheet (regression: development dropped them on stubbed child sheets)."""
+    circuit = Circuit(name="two_stage_power")
+    _build_two_stage_power_design(circuit)
+    circuit.generate_schematic(
+        filepath=output_dir, top_name="two_stage_power",
+        auto_stub=True, auto_stub_fanout=2,
+    )
+    missing = _power_symbol_integrity(output_dir)
+    assert not missing, f"power symbols emitted without definitions: {missing}"


### PR DESCRIPTION
> ## ⚠️ Merge order — please read first
> This is one of a **4-PR dependency stack that must merge bottom-up in order:**
> **#308 → #309 → #310 → #311**
> All four target `development` directly (GitHub requires the base branch to live in this repo), so until the PRs below this one merge, this PR's diff also shows *their* commits. Each PR's diff cleans up to just its own changes once the ones beneath it land. **Merge this one first** — it's the base of the stack and is independently safe.

Emit each sheet's `power:*` `lib_symbols` definitions from the power-symbol **instances actually placed on that sheet**, instead of a module-global accumulator seeded by scanning `node.wires`.

### The bug
On the `development` branch, hierarchical sheets can place `power:GND` / `power:VBUS` / etc. symbol *instances* without embedding their `lib_symbols` definitions. EESCHEMA then draws the missing-symbol **`?` placeholder** for those instances; `kicad-cli` silently skips them (which is why an SVG export looks fine while the GUI doesn't).

On `tests/examples/schematics/esp32_audio_board.py` this hit `usb_charger1` (GND+VBUS, *zero* defs) and `power_supply1` (missing VCC).

### Root cause
`node_to_sexp_schematic` built the per-sheet power set from a global `_used_power_symbols` set populated by a `node.wires` scan — but power nets are drawn as **stub labels, not wires**, and the scan ran *before* the instances were emitted. Defs and instances were computed by two different mechanisms at two different times, so they drifted per sheet and per processing order.

### Fix
Collect the power defs for a sheet by the same predicate that emits the instances (every NetTerminal pin / stub pin connected to a power-symbol net). Now every placed `power:*` lib_id resolves to an embedded def on its own sheet — verified `MISSING=[]` across all 6 esp32 sheets.

**Before / after** (esp32 `usb_charger1`, power defs stripped vs present — identical placement):
![before/after](https://raw.githubusercontent.com/lachlanfysh/skidl/302-assets/pr-ladder-renders/PR1_power-symbol-defs.png)

Test: `tests/unit_tests/ai_tests/test_dev_base_fixes.py` (asserts def==instance closure per sheet).

---
*Part 1 of 4 in a dependent stack (power-defs → snap+bus-fan → net-labels → backend refactor). This one is independent and safe to merge first.*
