### PR TITLE
fix(kicad9): net-label deconfliction + extend-away orientation

### DIFF
--- a/src/skidl/schematics/place.py
+++ b/src/skidl/schematics/place.py
@@ -273,6 +273,31 @@ def adjust_orientations(parts, **options):
         bool: True if one or more part orientations were changed. Otherwise, False.
     """
 
+    # Label-overlap-aware orientation: combine the existing net_tension with a
+    # term that penalizes orientations whose net labels would pile onto symbol
+    # bodies / other labels.  Opt-in (default on) and purely additive so it can
+    # be offered upstream without changing net_tension itself.
+    #
+    # Scope: by default this is applied to FLOATING parts (all pins on labeled
+    # stub nets), where label piling is worst and net_tension is ~0 so it does
+    # no electrical harm.  For wire-connected groups the label term is left OFF
+    # by default (`label_aware_connected`) because nudging a connected part's
+    # orientation purely for label readability can push a stub label onto an
+    # adjacent power node and merge nets.  Callers can flip either gate.
+    label_aware = options.get("label_aware_orientation", True) and options.get(
+        "_label_aware_scope", True
+    )
+    # Weight so a single label overlap (cost 1.0) outweighs small net_tension
+    # differences (net_tension is a distance sum in mils).
+    label_weight = options.get("label_overlap_weight", 75.0)
+
+    def orientation_cost(part):
+        """Combined orientation cost: net tension plus optional label overlap."""
+        cost = net_tension(part, **options)
+        if label_aware:
+            cost += label_weight * label_overlap_cost(part, **options)
+        return cost
+
     def find_best_orientation(part):
         """Each part has 8 possible orientations. Find the best of the 7 alternatives from the starting one."""
 
@@ -291,12 +316,12 @@ def adjust_orientations(parts, **options):
 
                 if calc_starting_cost:
                     # Calculate the cost of the starting orientation before any changes in orientation.
-                    starting_cost = net_tension(part, **options)
+                    starting_cost = orientation_cost(part)
                     # Skip the starting orientation but set flag to process the others.
                     calc_starting_cost = False
                 else:
                     # Calculate the cost of the current orientation.
-                    delta_cost = net_tension(part, **options) - starting_cost
+                    delta_cost = orientation_cost(part) - starting_cost
                     if delta_cost < best_delta_cost:
                         # Save the largest decrease in cost and the associated orientation.
                         best_delta_cost = delta_cost
@@ -321,6 +346,12 @@ def adjust_orientations(parts, **options):
     if not movable_parts:
         # No movable parts, so exit without doing anything.
         return
+
+    # Provide neighbor parts to the label-overlap cost so it can penalize a
+    # part's labels piling onto other parts' bodies.  Use all parts in scope.
+    if label_aware:
+        options = dict(options)
+        options["_label_neighbors"] = list(parts)
 
     # Kernighan-Lin algorithm for finding near-optimal part orientations.
     # Because of the way the tension for part alignment is computed based on
@@ -409,6 +440,168 @@ def net_tension_dist(part, **options):
             tension += min(dists)
 
     return tension
+
+
+# Geometry constants for estimating where a stubbed pin's net label will render.
+# Units are the same as pin.pt / part.tx (KiCad mils at place time; GRID == 50).
+# A net label is drawn as a flag starting at the pin and extending OUTWARD
+# (in the pin's transformed direction) by roughly the text length.  These
+# constants describe that flag box used purely for overlap scoring; they do
+# not have to match the renderer exactly, only correlate with visible piling.
+LABEL_REACH = 250.0  # outward length of a net-label flag box (~text length).
+LABEL_HALF_H = 30.0  # perpendicular half-height of a net-label flag box.
+# Body margin added around the bare pin-span so the body box also covers the
+# pin-name letters that crowd a rotated symbol.
+LABEL_BODY_MARGIN = 40.0
+# The reference/value text renders HORIZONTALLY in sheet space, centered on the
+# part body, regardless of part rotation.  A net label pointing up/down crosses
+# this horizontal text band (vertical, hard-to-read labels piling onto the
+# value text); a label pointing left/right clears it.  Penalizing overlap with
+# this axis-aligned band is what makes the cost prefer readable, splayed-out
+# horizontal labels over vertical ones.  These are the band's half-extents.
+LABEL_TEXT_BAND_HALF_W = 300.0  # horizontal half-width of the value/ref text band.
+LABEL_TEXT_BAND_HALF_H = 70.0   # vertical half-height of the value/ref text band.
+
+
+def _pin_out_dir(pin):
+    """Return the outward unit Point for a pin under its part's current tx.
+
+    Mirrors the direction logic in calc_pin_dir / add_place_pt: take the pin's
+    base orientation unit vector and rotate it by the part's rotation/flip
+    (translation stripped from part.tx).
+    """
+    tx = pin.part.tx
+    rot = Tx(a=tx.a, b=tx.b, c=tx.c, d=tx.d)  # strip translation, keep rot/flip.
+    base = {
+        "U": Point(0, 1),
+        "D": Point(0, -1),
+        "L": Point(-1, 0),
+        "R": Point(1, 0),
+    }[pin.orientation]
+    v = base * rot
+    # Snap to a clean axis-aligned unit vector.
+    return Point(
+        1 if v.x > 0.5 else (-1 if v.x < -0.5 else 0),
+        1 if v.y > 0.5 else (-1 if v.y < -0.5 else 0),
+    )
+
+
+def _label_box(anchor, out_dir):
+    """Build the flag bbox for a net label anchored at `anchor` extending
+    `LABEL_REACH` outward along `out_dir`, with `LABEL_HALF_H` to each side."""
+    far = anchor + out_dir * LABEL_REACH
+    box = BBox(anchor, far)
+    # Widen perpendicular to the reach direction.
+    if out_dir.y == 0:
+        # Horizontal label: pad in y.
+        return box.resize(Vector(0, LABEL_HALF_H))
+    elif out_dir.x == 0:
+        # Vertical label: pad in x.
+        return box.resize(Vector(LABEL_HALF_H, 0))
+    return box.resize(Vector(LABEL_HALF_H, LABEL_HALF_H))
+
+
+def _body_box(part):
+    """Estimate the part's own body box (graphics + pin-name letters) under its
+    current tx, derived from the span of its pin points so it stays
+    backend-agnostic.  A margin covers the pin-name letters."""
+    pts = [pin.pt for pin in part if getattr(pin, "pt", None) is not None]
+    if not pts:
+        return None
+    body = BBox(*pts)
+    body = body.resize(Vector(LABEL_BODY_MARGIN, LABEL_BODY_MARGIN))
+    return body * part.tx
+
+
+def _text_band_box(part):
+    """Axis-aligned box approximating the part's reference/value text, which
+    renders HORIZONTALLY in sheet space centered on the body regardless of part
+    rotation.  Net labels pointing up/down cross this band (and pile onto the
+    value text); labels pointing left/right clear it.  Returns the band in
+    sheet coordinates (only its CENTER is transformed, not its orientation)."""
+    pts = [pin.pt for pin in part if getattr(pin, "pt", None) is not None]
+    if not pts:
+        return None
+    ctr = (BBox(*pts) * part.tx).ctr
+    return BBox(
+        Point(ctr.x - LABEL_TEXT_BAND_HALF_W, ctr.y - LABEL_TEXT_BAND_HALF_H),
+        Point(ctr.x + LABEL_TEXT_BAND_HALF_W, ctr.y + LABEL_TEXT_BAND_HALF_H),
+    )
+
+
+def label_overlap_cost(part, **options):
+    """Estimate how badly this part's net labels will pile onto things.
+
+    For the part's CURRENT orientation (part.tx), each stubbed, connected pin
+    gets a net label that renders as a flag extending outward from the pin.
+    This returns a weighted count of overlaps where those flag boxes collide
+    with: (a) any OTHER part's place_bbox, (b) this part's own body box, or
+    (c) another of this part's own net-label flags.  Higher == worse/messier.
+
+    Backend-agnostic: uses only geometry already on parts/pins (pin.pt,
+    pin.orientation, pin.stub, pin.is_connected(), part.tx, part.place_bbox).
+    """
+    # Collect the stubbed, connected, label-bearing pins.
+    lbl_pins = [
+        pin
+        for pin in part
+        if getattr(pin, "stub", False)
+        and getattr(pin, "pt", None) is not None
+        and pin.is_connected()
+    ]
+    if not lbl_pins:
+        return 0.0
+
+    # Build a flag box for each labeled pin under the current orientation.
+    boxes = []
+    for pin in lbl_pins:
+        anchor = pin.pt * part.tx
+        out_dir = _pin_out_dir(pin)
+        boxes.append(_label_box(anchor, out_dir))
+
+    cost = 0.0
+
+    # (b) Label flag over this part's OWN body.
+    own_body = _body_box(part)
+    if own_body is not None:
+        for box in boxes:
+            if box.intersects(own_body):
+                cost += 1.0
+
+    # (b2) Label flag crossing the part's horizontal reference/value text band.
+    # This is what discriminates between rotations: a label pointing up/down
+    # cuts across the always-horizontal value text; a left/right label clears
+    # it.  Without this term the own-body/own-label geometry is rotation
+    # invariant (labels rotate with the part) and gives no preference.
+    text_band = _text_band_box(part)
+    if text_band is not None:
+        for pin, box in zip(lbl_pins, boxes):
+            out_dir = _pin_out_dir(pin)
+            # Only vertical labels (no horizontal component) cross the band.
+            if out_dir.x == 0 and box.intersects(text_band):
+                cost += 1.0
+
+    # (a) Label flag over a NEIGHBOR part's placement bbox.
+    neighbors = options.get("_label_neighbors", None)
+    if neighbors:
+        for other in neighbors:
+            if other is part:
+                continue
+            try:
+                other_bbox = other.place_bbox * other.tx
+            except AttributeError:
+                continue
+            for box in boxes:
+                if box.intersects(other_bbox):
+                    cost += 1.0
+
+    # (c) Two of this part's own labels overlapping each other.
+    for i in range(len(boxes)):
+        for j in range(i + 1, len(boxes)):
+            if boxes[i].intersects(boxes[j]):
+                cost += 1.0
+
+    return cost
 
 
 def net_torque_dist(part, **options):
@@ -1283,7 +1476,14 @@ class Placer:
 
         if options.get("rotate_parts"):
             # Adjust part orientations after first trial placement is done.
-            if adjust_orientations(real_parts, **options):
+            # Label-aware term is OFF here by default (connected parts) to avoid
+            # pushing a stub label onto an adjacent power node; opt in via
+            # label_aware_connected.
+            conn_opts = dict(options)
+            conn_opts["_label_aware_scope"] = options.get(
+                "label_aware_connected", False
+            )
+            if adjust_orientations(real_parts, **conn_opts):
                 # Some part orientations were changed, so re-do placement.
                 evolve_placement([], real_parts, nets, total_part_force, **options)
 
@@ -1368,6 +1568,20 @@ class Placer:
 
         # Do force-directed placement of the parts in the group.
         evolve_placement([], parts, [], force_func, **options)
+
+        # Floating parts have all their pins on labeled stub nets, so they get
+        # no orientation adjustment from the connected-parts path.  When the
+        # label-aware orientation term is enabled, run an orientation pass here
+        # so their net labels don't pile onto their own bodies / each other.
+        # net_tension is ~0 for floating parts (no real nets), so the label
+        # overlap cost is the dominant signal -- which is exactly what we want.
+        if options.get("rotate_parts") and options.get(
+            "label_aware_orientation", True
+        ):
+            float_opts = dict(options)
+            float_opts["_label_aware_scope"] = True  # always on for floating parts.
+            if adjust_orientations(parts, **float_opts):
+                evolve_placement([], parts, [], force_func, **options)
 
         if options.get("draw_placement"):
             # Pause to look at placement for debugging purposes.

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -433,6 +433,21 @@ def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2
         step_size = plan["step_size"]
         perp_dir = perp_map.get(ic_dir, ic_dir)
 
+        # Net labels sit on the IC's stubbed pins and extend outward along the
+        # same direction the fan staggers. Shift the whole fan out past the
+        # widest label so the first staggered part clears it instead of landing
+        # on top of it. Label width ~= (len(name)+1) * label-font (~50 mils).
+        # Capped so a long net name can't push the fan absurdly far.
+        _LABEL_CHAR_W = 50  # mils, ~KiCad PIN_LABEL_FONT_SIZE
+        label_clearance = 0
+        for _ic_pin, _ in matching:
+            _net = getattr(_ic_pin, "net", None)
+            if _net is not None and getattr(_ic_pin, "stub", False):
+                label_clearance = max(
+                    label_clearance, (len(_net.name) + 1) * _LABEL_CHAR_W
+                )
+        label_clearance = min(label_clearance, 800)
+
         def _pin_sort_key(entry, _ic_part=ic_part, _ic_dir=ic_dir):
             ic_pin = entry[0]
             w = ic_pin.pt * _ic_part.tx
@@ -452,8 +467,8 @@ def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2
             parts_list.sort(key=lambda t: getattr(t[0], "ref", ""))
 
             offset_n = pin_idx + 1
-            ox = ic_pin_world.x + step_dx * step_size * offset_n
-            oy = ic_pin_world.y + step_dy * step_size * offset_n
+            ox = ic_pin_world.x + step_dx * (label_clearance + step_size * offset_n)
+            oy = ic_pin_world.y + step_dy * (label_clearance + step_size * offset_n)
             junction_pt = Point(ox, oy)
 
             for part_idx, (part, my_pin, other_pin, _, _) in enumerate(parts_list):

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -451,7 +451,14 @@ def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2
             continue
         matching = [(ip, pl) for ip, pl in pin_entries if len(pl) == dominant]
 
-        if len(matching) < min_group:
+        # Stagger a fan when EITHER the pattern repeats across >= min_group IC
+        # pins (e.g. a row of 74HC165 inputs, each switch + pull-down), OR a
+        # single IC pin carries >= 2 two-pin parts (e.g. an MCU EN pin with a
+        # pull-up to VCC + a filter cap to GND). The single-pin case is the
+        # body-overlap bug: without staggering, the first part tees off the pin
+        # but the second chains colinearly back across the IC body.
+        single_pin_fan = dominant >= 2 and len(matching) >= 1
+        if len(matching) < min_group and not single_pin_fan:
             continue
 
         ic_part = matching[0][1][0][4]

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -71,6 +71,15 @@ def _is_power_net(net):
     return name.startswith("+") or bool(_POWER_NET_RE.match(name))
 
 
+_GND_NET_RE = re.compile(r"^(A|D|P)?GND$|^(VSS|VEE|GROUND)$", re.I)
+
+
+def _is_gnd_net(net):
+    """Return True if net is a ground rail (GND, AGND, VSS, etc.)."""
+    name = getattr(net, "name", "")
+    return bool(_GND_NET_RE.match(name))
+
+
 def _pin_world_orient(pin, part):
     """Get the world-space outward direction from a pin after part rotation.
 
@@ -157,6 +166,9 @@ def snap_two_pin_parts(node):
     node_part_ids = {id(p) for p in node.parts}
     snapped = set()
     occupied_pins = set()
+    # How many decoupling caps have already snapped onto each +supply pin, so
+    # additional caps on the same pin fan out instead of stacking.
+    power_pin_cap_idx = {}
 
     for part in list(node.parts):
         if not _is_two_pin_part(part):
@@ -177,6 +189,10 @@ def snap_two_pin_parts(node):
 
         for my_p, other_net in [(p1, net1), (p2, net2)]:
             if _is_power_net(other_net) and not both_power:
+                continue
+            # Decoupling caps (both pins on power) anchor only to the +supply
+            # pin, never GND — this clusters them at the IC's VIN/VDD pin.
+            if both_power and _is_gnd_net(other_net):
                 continue
             for net_pin in other_net.pins:
                 other_part = net_pin.part
@@ -203,8 +219,19 @@ def snap_two_pin_parts(node):
 
         part.tx = _compute_snap_tx(my_pin, other_pin, target_world, extend_dir)
         if both_power:
+            # Multiple decoupling caps share one +supply pin: push each out by a
+            # base offset along the pin, then fan successive caps perpendicular
+            # so they sit in a readable row instead of stacking on top of
+            # each other.
+            n = power_pin_cap_idx.get(id(target_pin), 0)
+            power_pin_cap_idx[id(target_pin)] = n + 1
             _offset_dir = {"R": (200, 0), "L": (-200, 0), "U": (0, 200), "D": (0, -200)}
-            dx, dy = _offset_dir.get(extend_dir, (200, 0))
+            ax, ay = _offset_dir.get(extend_dir, (200, 0))
+            # Unit perpendicular to the outward pin direction (rotate 90°).
+            perp_x, perp_y = (-ay // 200, ax // 200)
+            FAN_STEP = 300
+            dx = ax + perp_x * FAN_STEP * n
+            dy = ay + perp_y * FAN_STEP * n
             part.tx = part.tx.move(Point(dx, dy))
             # Emit a wire from the IC's power pin back to the now-offset cap +ve pin
             # so the connection is visually drawn rather than relying on two power
@@ -221,7 +248,11 @@ def snap_two_pin_parts(node):
             node._power_cap_suppressed_pins = power_cap_suppressed
         _stub_snapped_part(part)
         snapped.add(id(part))
-        occupied_pins.add(id(target_pin))
+        # Decoupling caps fan out off a shared +supply pin, so don't mark it
+        # occupied — let later caps cluster on the same pin. Single-target snaps
+        # still claim their pin so the next part finds a fresh one.
+        if not both_power:
+            occupied_pins.add(id(target_pin))
 
     for _iteration in range(5):
         newly_snapped = set()

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -1,0 +1,538 @@
+# -*- coding: utf-8 -*-
+
+# The MIT License (MIT) - Copyright (c) Dave Vandenbout.
+
+"""
+Backend-agnostic snap geometry for schematic generation.
+
+After placement+routing, two-pin parts (resistors, caps, LEDs, ...) are
+"snapped" so one of their pins lands exactly on the pin of a connected
+multi-pin part (an IC) or on the free pin of an already-snapped two-pin
+part.  This turns a sea of labelled stubs into directly-touching pins and
+short wires, which the KiCad emitter then renders without redundant labels.
+
+The geometry here is independent of any particular EDA tool: it operates on
+SKiDL Part/Pin/Net objects and SchNode trees, mutating ``part.tx`` and
+recording wire/suppression hints on the node:
+
+    node._tjunction_wires            list[(x1,y1,x2,y2)]  (mils, pre-sheet-tx)
+    node._tjunction_suppressed_pins  set[id(pin)]
+    node._power_cap_wires            list[(x1,y1,x2,y2)]  (mils, pre-sheet-tx)
+    node._power_cap_suppressed_pins  set[id(pin)]
+
+The tool-specific emitter (e.g. kicad9/sexp_schematic.py) reads these
+attributes to draw wires and suppress the corresponding pin labels.
+"""
+
+import re
+from collections import defaultdict
+
+from skidl.geometry import Point, Tx
+from skidl.schematics.net_terminal import NetTerminal
+
+
+# Pattern matching common power net names (kept in sync with the gen wrapper).
+_POWER_NET_RE = re.compile(
+    r"^(\+\d[\d.]*V[\d]*|GND|AGND|DGND|PGND|VCC|VDD|VSS|VEE|VBUS|VBAT|AVCC|AVDD|DVCC|DVDD)$",
+    re.IGNORECASE,
+)
+
+
+def _is_two_pin_part(part):
+    """Return True if part is a simple 2-pin component (LED, R, C, etc.)."""
+    return not isinstance(part, NetTerminal) and len(part.pins) == 2
+
+
+def _stub_snapped_part(part):
+    """Mark a snapped part's pins (and their nets) as stubbed.
+
+    Snapping moves a part AFTER routing, so any wire the router drew to it is
+    now stale. Converting its connections to labels (stubs) makes them
+    re-emit at the part's new position; the emitter then suppresses the
+    redundant ones where pins physically overlap. Explicit user stubs are
+    left untouched.
+    """
+    for pin in part.pins:
+        net = getattr(pin, "net", None)
+        if net is None or getattr(net, "_stub_explicit", False):
+            continue
+        pin.stub = True
+        try:
+            net._stub = True
+            for p in net.get_pins():
+                p.stub = True
+        except AttributeError:
+            pass
+
+
+def _is_power_net(net):
+    """Return True if net is a power rail (GND, VCC, +3.3V, etc.)."""
+    name = getattr(net, "name", "")
+    return name.startswith("+") or bool(_POWER_NET_RE.match(name))
+
+
+def _pin_world_orient(pin, part):
+    """Get the world-space outward direction from a pin after part rotation.
+
+    Transforms the pin's stub direction vector through the part's full
+    transform (including mirrors/flips), then returns the opposite direction.
+    """
+    orient_to_vec = {"R": (1, 0), "L": (-1, 0), "U": (0, -1), "D": (0, 1)}
+    outward = {"L": "R", "R": "L", "U": "D", "D": "U"}
+
+    raw_orient = getattr(pin, "orientation", "R")
+    vx, vy = orient_to_vec.get(raw_orient, (1, 0))
+    tx = part.tx
+    wx = tx.a * vx + tx.b * vy
+    wy = tx.c * vx + tx.d * vy
+    if abs(wx) >= abs(wy):
+        world_orient = "R" if wx > 0 else "L"
+    else:
+        world_orient = "D" if wy > 0 else "U"
+    return outward.get(world_orient, "R")
+
+
+def _compute_snap_tx(my_pin, other_pin, target_world, extend_dir):
+    """Compute the transform to snap a 2-pin part onto a target pin position.
+
+    Orients the part so `other_pin` extends in `extend_dir` from the target,
+    and places `my_pin` exactly at `target_world`.
+
+    Returns:
+        Tx: The new transform for the 2-pin part.
+    """
+    dx_local = other_pin.pt.x - my_pin.pt.x
+    dy_local = other_pin.pt.y - my_pin.pt.y
+
+    if extend_dir == "R":
+        if abs(dx_local) >= abs(dy_local):
+            symtx = "" if dx_local > 0 else "H"
+        else:
+            symtx = "R" if dy_local > 0 else "L"
+    elif extend_dir == "L":
+        if abs(dx_local) >= abs(dy_local):
+            symtx = "" if dx_local < 0 else "H"
+        else:
+            symtx = "L" if dy_local > 0 else "R"
+    elif extend_dir == "U":
+        if abs(dy_local) >= abs(dx_local):
+            symtx = "" if dy_local > 0 else "V"
+        else:
+            symtx = "L" if dx_local > 0 else "R"
+    elif extend_dir == "D":
+        if abs(dy_local) >= abs(dx_local):
+            symtx = "" if dy_local < 0 else "V"
+        else:
+            symtx = "R" if dx_local > 0 else "L"
+    else:
+        symtx = ""
+
+    new_tx = Tx.from_symtx(symtx)
+    my_pin_placed = my_pin.pt * new_tx
+    offset = Point(
+        target_world.x - my_pin_placed.x,
+        target_world.y - my_pin_placed.y,
+    )
+    return new_tx.move(offset)
+
+
+def snap_two_pin_parts(node):
+    """Snap 2-pin parts onto their connected IC or already-snapped part pins.
+
+    Pass 1: Snap onto IC pins (parts with >2 pins). Each IC pin only accepts
+    one snapped part; extras keep their labels.
+
+    Pass 2+: Iteratively snap remaining 2-pin parts onto the free pins of
+    already-snapped 2-pin parts, building chains (e.g. IC <- R <- LED).
+
+    Pass 3: Stack remaining 2-pin parts onto already-occupied IC pins,
+    extending perpendicular to the first snapped part. Handles nets shared
+    between multiple 2-pin parts (e.g. switch + pull-down on the same IC input).
+
+    Recurses into child nodes first.
+    """
+    for child in node.children.values():
+        snap_two_pin_parts(child)
+
+    node_part_ids = {id(p) for p in node.parts}
+    snapped = set()
+    occupied_pins = set()
+
+    for part in list(node.parts):
+        if not _is_two_pin_part(part):
+            continue
+
+        p1, p2 = part.pins[0], part.pins[1]
+        net1 = getattr(p1, "net", None)
+        net2 = getattr(p2, "net", None)
+        if not net1 or not net2:
+            continue
+
+        target_pin = None
+        target_part = None
+        my_pin = None
+
+        both_power = _is_power_net(net1) and _is_power_net(net2)
+        min_target_pins = 8 if both_power else 2
+
+        for my_p, other_net in [(p1, net1), (p2, net2)]:
+            if _is_power_net(other_net) and not both_power:
+                continue
+            for net_pin in other_net.pins:
+                other_part = net_pin.part
+                if (
+                    other_part is not part
+                    and id(other_part) in node_part_ids
+                    and not isinstance(other_part, NetTerminal)
+                    and len(other_part.pins) > min_target_pins
+                    and id(net_pin) not in occupied_pins
+                ):
+                    target_pin = net_pin
+                    target_part = other_part
+                    my_pin = my_p
+                    break
+            if target_pin:
+                break
+
+        if not target_pin:
+            continue
+
+        target_world = target_pin.pt * target_part.tx
+        extend_dir = _pin_world_orient(target_pin, target_part)
+        other_pin = p2 if my_pin is p1 else p1
+
+        part.tx = _compute_snap_tx(my_pin, other_pin, target_world, extend_dir)
+        if both_power:
+            _offset_dir = {"R": (200, 0), "L": (-200, 0), "U": (0, 200), "D": (0, -200)}
+            dx, dy = _offset_dir.get(extend_dir, (200, 0))
+            part.tx = part.tx.move(Point(dx, dy))
+            # Emit a wire from the IC's power pin back to the now-offset cap +ve pin
+            # so the connection is visually drawn rather than relying on two power
+            # labels. Suppress the cap +ve pin's label since the wire makes it
+            # redundant.
+            cap_pin_world = my_pin.pt * part.tx
+            power_cap_wires = getattr(node, "_power_cap_wires", [])
+            power_cap_wires.append(
+                (target_world.x, target_world.y, cap_pin_world.x, cap_pin_world.y)
+            )
+            node._power_cap_wires = power_cap_wires
+            power_cap_suppressed = getattr(node, "_power_cap_suppressed_pins", set())
+            power_cap_suppressed.add(id(my_pin))
+            node._power_cap_suppressed_pins = power_cap_suppressed
+        _stub_snapped_part(part)
+        snapped.add(id(part))
+        occupied_pins.add(id(target_pin))
+
+    for _iteration in range(5):
+        newly_snapped = set()
+
+        for part in list(node.parts):
+            if id(part) in snapped or not _is_two_pin_part(part):
+                continue
+
+            p1, p2 = part.pins[0], part.pins[1]
+            net1 = getattr(p1, "net", None)
+            net2 = getattr(p2, "net", None)
+            if not net1 or not net2:
+                continue
+
+            target_pin = None
+            target_part = None
+            my_pin = None
+
+            both_power = _is_power_net(net1) and _is_power_net(net2)
+
+            for my_p, other_net in [(p1, net1), (p2, net2)]:
+                if _is_power_net(other_net) and not both_power:
+                    continue
+                for net_pin in other_net.pins:
+                    other_part = net_pin.part
+                    if (
+                        other_part is not part
+                        and id(other_part) in snapped
+                        and id(net_pin) not in occupied_pins
+                    ):
+                        target_pin = net_pin
+                        target_part = other_part
+                        my_pin = my_p
+                        break
+                if target_pin:
+                    break
+
+            if not target_pin:
+                continue
+
+            target_world = target_pin.pt * target_part.tx
+            extend_dir = _pin_world_orient(target_pin, target_part)
+            other_pin = p2 if my_pin is p1 else p1
+
+            part.tx = _compute_snap_tx(my_pin, other_pin, target_world, extend_dir)
+            _stub_snapped_part(part)
+            newly_snapped.add(id(part))
+            occupied_pins.add(id(target_pin))
+
+        if not newly_snapped:
+            break
+        snapped |= newly_snapped
+
+    perp_map = {"R": "D", "L": "U", "U": "R", "D": "L"}
+    for part in list(node.parts):
+        if id(part) in snapped or not _is_two_pin_part(part):
+            continue
+
+        p1, p2 = part.pins[0], part.pins[1]
+        net1 = getattr(p1, "net", None)
+        net2 = getattr(p2, "net", None)
+        if not net1 or not net2:
+            continue
+
+        target_pin = None
+        target_part = None
+        my_pin = None
+
+        for my_p, other_net in [(p1, net1), (p2, net2)]:
+            for net_pin in other_net.pins:
+                other_part = net_pin.part
+                if (
+                    other_part is not part
+                    and id(other_part) in node_part_ids
+                    and not isinstance(other_part, NetTerminal)
+                    and len(other_part.pins) > 2
+                    and id(net_pin) in occupied_pins
+                ):
+                    target_pin = net_pin
+                    target_part = other_part
+                    my_pin = my_p
+                    break
+            if target_pin:
+                break
+
+        if not target_pin:
+            continue
+
+        target_world = target_pin.pt * target_part.tx
+        ic_dir = _pin_world_orient(target_pin, target_part)
+        extend_dir = perp_map.get(ic_dir, ic_dir)
+        other_pin = p2 if my_pin is p1 else p1
+
+        part.tx = _compute_snap_tx(my_pin, other_pin, target_world, extend_dir)
+        _stub_snapped_part(part)
+        snapped.add(id(part))
+
+    _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins)
+
+
+def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2):
+    """Detect repeating T-junction patterns and stagger parts outward from IC.
+
+    Phase 1: identify stagger groups, compute how much space each needs,
+    and shift ICs apart vertically so fans won't overlap.
+    Phase 2: place the staggered parts at the (now separated) IC positions.
+    """
+    perp_map = {"R": "D", "L": "U", "U": "R", "D": "L"}
+    anti_perp = {"U": "D", "D": "U", "L": "R", "R": "L"}
+    _dir_vec = {"R": (1, 0), "L": (-1, 0), "U": (0, -1), "D": (0, 1)}
+
+    ic_pin_to_parts = defaultdict(list)
+
+    for part in node.parts:
+        if not _is_two_pin_part(part):
+            continue
+
+        p1, p2 = part.pins[0], part.pins[1]
+        net1 = getattr(p1, "net", None)
+        net2 = getattr(p2, "net", None)
+        if not net1 or not net2:
+            continue
+
+        for my_p, other_net in [(p1, net1), (p2, net2)]:
+            if _is_power_net(other_net):
+                continue
+            for net_pin in other_net.pins:
+                ic = net_pin.part
+                if (
+                    ic is not part
+                    and id(ic) in node_part_ids
+                    and not isinstance(ic, NetTerminal)
+                    and len(ic.pins) > 2
+                    and id(net_pin) in occupied_pins
+                ):
+                    other_pin = p2 if my_p is p1 else p1
+                    ic_pin_to_parts[id(net_pin)].append(
+                        (part, my_p, other_pin, net_pin, ic)
+                    )
+                    break
+            else:
+                continue
+            break
+
+    ic_groups = defaultdict(list)
+    for ic_pin_id, parts_list in ic_pin_to_parts.items():
+        if not parts_list:
+            continue
+        ic = parts_list[0][4]
+        ic_groups[id(ic)].append((parts_list[0][3], parts_list))
+
+    # Phase 1: identify qualifying groups and pre-shift ICs.
+    MM_TO_MILS = 1 / 0.0254
+    stagger_plans = []
+
+    for ic_id, pin_entries in ic_groups.items():
+        fanout_counts = [len(pl) for _, pl in pin_entries]
+        dominant = max(set(fanout_counts), key=fanout_counts.count)
+        if dominant < 2:
+            continue
+        matching = [(ip, pl) for ip, pl in pin_entries if len(pl) == dominant]
+
+        if len(matching) < min_group:
+            continue
+
+        ic_part = matching[0][1][0][4]
+        ic_dir = _pin_world_orient(matching[0][0], ic_part)
+        step_dx, step_dy = _dir_vec.get(ic_dir, (1, 0))
+
+        max_span = 0
+        for _, parts_list_scan in matching:
+            for (scan_part, _, _, _, _) in parts_list_scan:
+                pts = [getattr(p, "pt", Point(p.x * MM_TO_MILS, p.y * MM_TO_MILS)) for p in scan_part.pins]
+                if pts:
+                    span = max(
+                        max(p.x for p in pts) - min(p.x for p in pts),
+                        max(p.y for p in pts) - min(p.y for p in pts),
+                    )
+                    max_span = max(max_span, span)
+        step_size = max(100, int(max_span) + 50)
+
+        n_pins = len(matching)
+        stagger_extent = step_size * n_pins + max_span
+
+        stagger_plans.append({
+            "ic_part": ic_part,
+            "matching": matching,
+            "ic_dir": ic_dir,
+            "step_dx": step_dx,
+            "step_dy": step_dy,
+            "step_size": step_size,
+            "stagger_extent": stagger_extent,
+            "dominant": dominant,
+        })
+
+    if len(stagger_plans) > 1:
+        _pre_shift_ics(stagger_plans, node, snapped)
+
+    # Phase 2: place staggered parts at final IC positions.
+    junction_wires = getattr(node, "_tjunction_wires", [])
+    suppressed_pins = set()
+
+    for plan in stagger_plans:
+        ic_part = plan["ic_part"]
+        matching = plan["matching"]
+        ic_dir = plan["ic_dir"]
+        step_dx = plan["step_dx"]
+        step_dy = plan["step_dy"]
+        step_size = plan["step_size"]
+        perp_dir = perp_map.get(ic_dir, ic_dir)
+
+        def _pin_sort_key(entry, _ic_part=ic_part, _ic_dir=ic_dir):
+            ic_pin = entry[0]
+            w = ic_pin.pt * _ic_part.tx
+            if _ic_dir in ("L", "R"):
+                return w.y
+            return w.x
+
+        matching.sort(key=_pin_sort_key)
+
+        parts_per_pin = plan["dominant"]
+        anti = anti_perp.get(perp_dir, perp_dir)
+        extend_dirs = [perp_dir, anti] if parts_per_pin >= 2 else [perp_dir]
+
+        for pin_idx, (ic_pin, parts_list) in enumerate(matching):
+            ic_pin_world = ic_pin.pt * ic_part.tx
+
+            parts_list.sort(key=lambda t: getattr(t[0], "ref", ""))
+
+            offset_n = pin_idx + 1
+            ox = ic_pin_world.x + step_dx * step_size * offset_n
+            oy = ic_pin_world.y + step_dy * step_size * offset_n
+            junction_pt = Point(ox, oy)
+
+            for part_idx, (part, my_pin, other_pin, _, _) in enumerate(parts_list):
+                ext_dir = extend_dirs[part_idx % len(extend_dirs)]
+                part.tx = _compute_snap_tx(
+                    my_pin, other_pin, junction_pt, ext_dir
+                )
+                _stub_snapped_part(part)
+                snapped.add(id(part))
+                suppressed_pins.add(id(my_pin))
+            junction_wires.append(
+                (ic_pin_world.x, ic_pin_world.y, ox, oy)
+            )
+
+    node._tjunction_wires = junction_wires
+    node._tjunction_suppressed_pins = suppressed_pins
+
+
+def _pre_shift_ics(plans, node, snapped):
+    """Shift ICs vertically BEFORE stagger placement so fans won't overlap.
+
+    Collects all parts already snapped to each IC and moves them together.
+    The stagger parts haven't been placed yet, so they'll naturally land
+    at the shifted IC positions in phase 2.
+    """
+    for plan in plans:
+        ic = plan["ic_part"]
+        ic_deps = set()
+        ic_id = id(ic)
+
+        for part in node.parts:
+            if id(part) == ic_id or id(part) not in snapped:
+                continue
+            if not _is_two_pin_part(part):
+                continue
+            for pin in part.pins:
+                net = getattr(pin, "net", None)
+                if not net:
+                    continue
+                for net_pin in net.pins:
+                    if net_pin.part is ic:
+                        ic_deps.add(id(part))
+                        break
+                if id(part) in ic_deps:
+                    break
+
+        plan["_deps"] = [p for p in node.parts if id(p) in ic_deps]
+
+    def _ic_bbox(plan):
+        ic = plan["ic_part"]
+        all_parts = [ic] + plan["_deps"]
+        min_y = float("inf")
+        max_y = float("-inf")
+        for part in all_parts:
+            for pin in part.pins:
+                w = pin.pt * part.tx
+                min_y = min(min_y, w.y)
+                max_y = max(max_y, w.y)
+        return min_y, max_y
+
+    plans.sort(key=lambda p: _ic_bbox(p)[0])
+
+    margin = 200
+    prev_max_y = None
+
+    for plan in plans:
+        ic_min_y, ic_max_y = _ic_bbox(plan)
+        needed_height = plan["stagger_extent"]
+        group_max_y = max(ic_max_y, ic_min_y + needed_height)
+
+        if prev_max_y is not None and ic_min_y < prev_max_y + margin:
+            shift = (prev_max_y + margin) - ic_min_y
+            vec = Point(0, shift)
+            shifted = set()
+            for part in [plan["ic_part"]] + plan["_deps"]:
+                if id(part) not in shifted:
+                    part.tx = part.tx.move(vec)
+                    shifted.add(id(part))
+            ic_min_y += shift
+            group_max_y += shift
+
+        prev_max_y = group_max_y

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -18,6 +18,7 @@ recording wire/suppression hints on the node:
     node._tjunction_wires            list[(x1,y1,x2,y2)]  (mils, pre-sheet-tx)
     node._tjunction_suppressed_pins  set[id(pin)]
     node._power_cap_wires            list[(x1,y1,x2,y2)]  (mils, pre-sheet-tx)
+    node._power_cap_junctions        list[Point]          (mils, pre-sheet-tx)
     node._power_cap_suppressed_pins  set[id(pin)]
 
 The tool-specific emitter (e.g. kicad9/sexp_schematic.py) reads these
@@ -178,6 +179,9 @@ def snap_two_pin_parts(node):
     # How many decoupling caps have already snapped onto each +supply pin, so
     # additional caps on the same pin fan out instead of stacking.
     power_pin_cap_idx = {}
+    # Per +supply pin: the snapped cap +ve pin positions, so the fan can be
+    # routed as a single right-angle bus instead of a star of diagonals.
+    power_cap_groups = {}
 
     for part in list(node.parts):
         if not _is_two_pin_part(part):
@@ -247,11 +251,10 @@ def snap_two_pin_parts(node):
             # labels. Suppress the cap +ve pin's label since the wire makes it
             # redundant.
             cap_pin_world = my_pin.pt * part.tx
-            power_cap_wires = getattr(node, "_power_cap_wires", [])
-            power_cap_wires.append(
-                (target_world.x, target_world.y, cap_pin_world.x, cap_pin_world.y)
+            grp = power_cap_groups.setdefault(
+                id(target_pin), {"target": target_world, "caps": []}
             )
-            node._power_cap_wires = power_cap_wires
+            grp["caps"].append(cap_pin_world)
             power_cap_suppressed = getattr(node, "_power_cap_suppressed_pins", set())
             power_cap_suppressed.add(id(my_pin))
             node._power_cap_suppressed_pins = power_cap_suppressed
@@ -262,6 +265,30 @@ def snap_two_pin_parts(node):
         # still claim their pin so the next part finds a fresh one.
         if not both_power:
             occupied_pins.add(id(target_pin))
+
+    # Route each +supply pin's decoupling caps as a right-angle bus rather than
+    # a star of diagonals: a single trunk along the (collinear) cap +ve pins,
+    # plus a short orthogonal connector from the IC pin onto the trunk, with a
+    # junction dot at every tap. The caps were placed at
+    # target + base*along + n*FAN_STEP*perp, so trunk and connector are
+    # axis-aligned by construction.
+    if power_cap_groups:
+        power_cap_wires = getattr(node, "_power_cap_wires", [])
+        power_cap_junctions = getattr(node, "_power_cap_junctions", [])
+        for grp in power_cap_groups.values():
+            t = grp["target"]
+            caps = grp["caps"]
+            # connector: IC pin -> first cap pin, along the pin's outward axis
+            power_cap_wires.append((t.x, t.y, caps[0].x, caps[0].y))
+            # trunk: consecutive cap +ve pins (the perpendicular fan row)
+            for a, b in zip(caps, caps[1:]):
+                power_cap_wires.append((a.x, a.y, b.x, b.y))
+            # junction at every tap where 3 segments/pins meet (all taps except
+            # the trunk's far endpoint, which is a plain wire-end-on-pin)
+            for cap in caps[:-1]:
+                power_cap_junctions.append(cap)
+        node._power_cap_wires = power_cap_wires
+        node._power_cap_junctions = power_cap_junctions
 
     for _iteration in range(5):
         newly_snapped = set()

--- a/src/skidl/schematics/snap.py
+++ b/src/skidl/schematics/snap.py
@@ -31,6 +31,15 @@ from skidl.geometry import Point, Tx
 from skidl.schematics.net_terminal import NetTerminal
 
 
+# PROPOSAL FLAG (default OFF): when True, _stagger_tjunctions drops a junction
+# dot at each fan's shared point and suppresses the IC-pin net label, relying on
+# pure pin-to-pin/wire connectivity for the fan net.  This removes the redundant
+# SW_n label but MUST be validated with real IC-fan ERC (kicad-cli sch erc) on a
+# board that actually triggers staggered T-junction fans before being enabled,
+# because the IC-pin label is currently load-bearing (see finding #7).
+_ENABLE_IC_FAN_PIN_REWIRE = False
+
+
 # Pattern matching common power net names (kept in sync with the gen wrapper).
 _POWER_NET_RE = re.compile(
     r"^(\+\d[\d.]*V[\d]*|GND|AGND|DGND|PGND|VCC|VDD|VSS|VEE|VBUS|VBAT|AVCC|AVDD|DVCC|DVDD)$",
@@ -453,6 +462,7 @@ def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2
 
     # Phase 2: place staggered parts at final IC positions.
     junction_wires = getattr(node, "_tjunction_wires", [])
+    junction_dots = getattr(node, "_tjunction_junctions", [])
     suppressed_pins = set()
 
     for plan in stagger_plans:
@@ -514,7 +524,20 @@ def _stagger_tjunctions(node, node_part_ids, snapped, occupied_pins, min_group=2
                 (ic_pin_world.x, ic_pin_world.y, ox, oy)
             )
 
+            # PROPOSAL (needs real IC-fan ERC before enabling — see note below):
+            # The fan's pin-to-pin geometry is already a fully-connected chain:
+            # a wire IC-pin -> junction_pt and >= 2 fan `my_pin`s coincident at
+            # junction_pt.  With a junction dot dropped at the shared point the
+            # net is resolvable by connectivity alone, so the SW_n label that
+            # currently sits on the IC pin (load-bearing today, finding #7) can
+            # be suppressed without dangling the wire.  Three or more pins meet
+            # at junction_pt (>=2 fan pins + 1 wire end) so a dot is required.
+            if _ENABLE_IC_FAN_PIN_REWIRE and len(parts_list) >= 2:
+                junction_dots.append(Point(ox, oy))
+                suppressed_pins.add(id(ic_pin))
+
     node._tjunction_wires = junction_wires
+    node._tjunction_junctions = junction_dots
     node._tjunction_suppressed_pins = suppressed_pins
 
 

--- a/src/skidl/tools/kicad9/gen_schematic.py
+++ b/src/skidl/tools/kicad9/gen_schematic.py
@@ -17,6 +17,7 @@ from collections import Counter
 
 from skidl.geometry import BBox, Point, Tx, Vector
 from skidl.schematics.net_terminal import NetTerminal
+from skidl.schematics.snap import snap_two_pin_parts as _snap_two_pin_parts
 from skidl.scriptinfo import get_script_name
 from skidl.utilities import export_to_all, rmv_attr
 
@@ -110,6 +111,67 @@ def auto_stub_nets(circuit, **options):
     active_logger.info(
         f"  [auto_stub] fanout>={fanout_threshold}: {', '.join(stubbed_fanout[:10])}{'...' if len(stubbed_fanout) > 10 else ''}"
     )
+
+
+def _apply_deferred_stubs(node, circuit, **options):
+    """Apply deferred stubs per-subcircuit after placement.
+
+    Nets marked _deferred_stub are examined within each child node.
+    Simple internal connections (few pins, close together) remain as wires;
+    complex or distant ones get stubbed.
+
+    NetTerminal parts (schematic-only label placeholders) are excluded from
+    the pin count so they don't inflate it beyond the real circuit connectivity.
+    """
+    from skidl.logger import active_logger
+
+    # Reset pin.stub for all deferred-stub nets (supports retries).
+    for net in circuit.nets:
+        if getattr(net, "_deferred_stub", False):
+            net._stub = False
+            for p in net.get_pins():
+                p.stub = False
+
+    for child in node.children.values():
+        child_name = getattr(child, "name", "?")
+        child_parts = set(child.parts)
+        stubbed = 0
+        seen = set()
+
+        for part in child.parts:
+            for pin in part:
+                if not pin.is_connected():
+                    continue
+                net = pin.net
+                if id(net) in seen:
+                    continue
+                seen.add(id(net))
+
+                if not getattr(net, "_deferred_stub", False):
+                    continue
+
+                internal_pins = [p for p in net.pins if p.part in child_parts]
+
+                # Deferred nets were kept un-stubbed during placement
+                # for connectivity-aware grouping.  Now stub them all —
+                # labels at pins are cleaner than routed wires for
+                # cross-sheet connections.
+                for p in internal_pins:
+                    p.stub = True
+                stubbed += 1
+
+        if stubbed:
+            active_logger.info(
+                f"  [deferred_stub] {child_name}: {stubbed} deferred nets stubbed"
+            )
+
+    # Set net._stub for nets where ALL pins ended up stubbed.
+    for net in circuit.nets:
+        if getattr(net, "_deferred_stub", False):
+            has_unstubbed = any(not p.stub for p in net.pins)
+            if not has_unstubbed:
+                net._stub = True
+                net._stub_explicit = False
 
 
 def _run_erc(schematic_path):
@@ -232,55 +294,93 @@ def _classify_and_stub_complex_nets(circuit, node, **options):
     max_wire_pins = options.get("auto_stub_max_wire_pins", 3)
     max_wire_dist = options.get("auto_stub_max_wire_dist", 2000)
 
-    node_parts = set(node.parts)
-    stubbed_count = 0
+    def _classify_node(target_node):
+        target_parts = set(target_node.parts)
+        count = 0
 
-    for net in node.get_internal_nets():
-        if getattr(net, "_stub_explicit", False):
-            continue
-        if getattr(net, "_stub", False):
-            continue
+        for net in target_node.get_internal_nets():
+            if getattr(net, "_stub_explicit", False):
+                continue
+            if getattr(net, "_stub", False):
+                continue
 
-        pins = [p for p in net.pins if p.part in node_parts]
+            pins = [p for p in net.pins if p.part in target_parts
+                    and not isinstance(p.part, NetTerminal)]
 
-        # Too many pins → label.
-        if len(pins) > max_wire_pins:
-            net._stub = True
-            net._stub_explicit = False
-            for p in net.get_pins():
-                p.stub = True
-            stubbed_count += 1
-            continue
-
-        # Pins too far apart → label.
-        if len(pins) >= 2:
-            pts = []
-            for p in pins:
-                pin_pt = getattr(p, "place_pt", getattr(p, "pt", Point(p.x, p.y)))
-                part_tx = getattr(p.part, "tx", None)
-                if part_tx:
-                    pts.append(pin_pt * part_tx)
-                else:
-                    pts.append(pin_pt)
-
-            max_dist = 0
-            for i, a in enumerate(pts):
-                for b in pts[i + 1:]:
-                    dist = abs(a.x - b.x) + abs(a.y - b.y)
-                    if dist > max_dist:
-                        max_dist = dist
-
-            if max_dist > max_wire_dist:
+            if len(pins) > max_wire_pins:
                 net._stub = True
                 net._stub_explicit = False
                 for p in net.get_pins():
                     p.stub = True
-                stubbed_count += 1
+                count += 1
+                continue
 
-    if stubbed_count:
+            if len(pins) >= 2:
+                pts = []
+                for p in pins:
+                    pin_pt = getattr(p, "place_pt", getattr(p, "pt", Point(p.x, p.y)))
+                    part_tx = getattr(p.part, "tx", None)
+                    if part_tx:
+                        pts.append(pin_pt * part_tx)
+                    else:
+                        pts.append(pin_pt)
+
+                max_dist = 0
+                for i, a in enumerate(pts):
+                    for b in pts[i + 1:]:
+                        dist = abs(a.x - b.x) + abs(a.y - b.y)
+                        if dist > max_dist:
+                            max_dist = dist
+
+                if max_dist > max_wire_dist:
+                    net._stub = True
+                    net._stub_explicit = False
+                    for p in net.get_pins():
+                        p.stub = True
+                    count += 1
+
+        return count
+
+    total_stubbed = _classify_node(node)
+    for child in node.children.values():
+        total_stubbed += _classify_node(child)
+
+    # Second pass on children: stub nets that can't benefit from wiring.
+    for child in node.children.values():
+        child_parts = set(child.parts)
+        child_internal = child.get_internal_nets()
+        non_stubbed = [n for n in child_internal
+                       if not getattr(n, "_stub", False)]
+
+        # Stub single-real-pin nets (cross-sheet labels, not wireable).
+        for net in non_stubbed:
+            real_pins = [p for p in net.pins if p.part in child_parts
+                         and not isinstance(p.part, NetTerminal)]
+            if len(real_pins) < 2:
+                net._stub = True
+                net._stub_explicit = False
+                for p in net.get_pins():
+                    p.stub = True
+                total_stubbed += 1
+
+        # Re-count after single-pin removal.
+        non_stubbed = [n for n in child_internal
+                       if not getattr(n, "_stub", False)]
+
+        # Stub all remaining nets in small subcircuits (<=6 routeable nets).
+        # Only large chain structures (switch->R->IC grids) benefit from wiring.
+        if len(non_stubbed) <= 6:
+            for net in non_stubbed:
+                net._stub = True
+                net._stub_explicit = False
+                for p in net.get_pins():
+                    p.stub = True
+                total_stubbed += 1
+
+    if total_stubbed:
         from skidl.logger import active_logger
         active_logger.info(
-            f"  [selective_routing] Stubbed {stubbed_count} complex nets after placement"
+            f"  [selective_routing] Stubbed {total_stubbed} complex/distant nets after placement"
         )
 
 
@@ -329,6 +429,7 @@ def _handle_fallback(circuit, tool_module, filepath, top_name, title, flatness,
     node = SchNode(circuit, tool_module, filepath, top_name, title, flatness)
     node.place(expansion_factor=1.0, **options)
     node.route(**options)
+    _snap_two_pin_parts(node)
     output_file = write_top_schematic(
         circuit, node, filepath, top_name, title, version=20230409
     )
@@ -593,6 +694,7 @@ def gen_schematic(
         try:
             node.place(expansion_factor=expansion_factor, **options)
             if options.get("auto_stub", False):
+                _apply_deferred_stubs(node, circuit, **options)
                 _classify_and_stub_complex_nets(circuit, node, **options)
             node.route(**options)
 
@@ -612,6 +714,9 @@ def gen_schematic(
                 f"Routing failed on attempt {attempt + 1}/{retries}, expanding area by 1.5x: {e}"
             )
             continue
+
+        if options.get("auto_stub", False):
+            _snap_two_pin_parts(node)
 
         # Generate S-expression schematic using shared module.
         # KiCad 8/9 use version 20230409.
@@ -662,8 +767,11 @@ def gen_schematic(
                         )
                         node.place(expansion_factor=erc_expansion, **options)
                         if options.get("auto_stub", False):
+                            _apply_deferred_stubs(node, circuit, **options)
                             _classify_and_stub_complex_nets(circuit, node, **options)
                         node.route(**options)
+                        if options.get("auto_stub", False):
+                            _snap_two_pin_parts(node)
                         output_file = write_top_schematic(
                             circuit, node, filepath, top_name, title, version=20230409
                         )

--- a/src/skidl/tools/kicad9/gen_schematic.py
+++ b/src/skidl/tools/kicad9/gen_schematic.py
@@ -71,6 +71,13 @@ def auto_stub_nets(circuit, **options):
     Only modifies nets that haven't been explicitly set by the user.
     Called when auto_stub=True is passed to gen_schematic().
 
+    Power nets are always stubbed immediately (they'd overwhelm the placer).
+    Fanout-based stubbing is DEFERRED: nets are marked ``_deferred_stub`` so
+    the placer still uses them for connectivity-based grouping, then they get
+    stubbed after placement via ``_apply_deferred_stubs()``. Stubbing them up
+    front instead scatters connected parts and makes dense boards (e.g. the
+    327-part Concentric board) fail to route, which suppresses snap placement.
+
     Args:
         circuit: The Circuit object containing nets to analyze.
         options: Dict of options. Recognizes 'auto_stub_fanout' (default 5).
@@ -79,7 +86,7 @@ def auto_stub_nets(circuit, **options):
 
     fanout_threshold = options.get("auto_stub_fanout", 5)
     stubbed_power = []
-    stubbed_fanout = []
+    deferred_fanout = []
 
     for net in circuit.nets:
         if getattr(net, "_stub_explicit", False):
@@ -96,20 +103,18 @@ def auto_stub_nets(circuit, **options):
             stubbed_power.append(f"{net.name}({len(net.pins)})")
             continue
 
-        # High fanout nets: many pins connected to the same net.
+        # High fanout nets: defer — keep connectivity for grouping during
+        # placement, stub after placement (see _apply_deferred_stubs).
         if len(net.pins) >= fanout_threshold:
-            net._stub = True
-            net._stub_explicit = False
-            for pin in net.get_pins():
-                pin.stub = True
-            stubbed_fanout.append(f"{net.name}({len(net.pins)})")
+            net._deferred_stub = True
+            deferred_fanout.append(f"{net.name}({len(net.pins)})")
 
     from skidl.logger import active_logger
     active_logger.info(
         f"  [auto_stub] power: {', '.join(stubbed_power[:10])}{'...' if len(stubbed_power) > 10 else ''}"
     )
     active_logger.info(
-        f"  [auto_stub] fanout>={fanout_threshold}: {', '.join(stubbed_fanout[:10])}{'...' if len(stubbed_fanout) > 10 else ''}"
+        f"  [auto_stub] deferred fanout>={fanout_threshold}: {', '.join(deferred_fanout[:10])}{'...' if len(deferred_fanout) > 10 else ''}"
     )
 
 

--- a/src/skidl/tools/kicad9/gen_schematic.py
+++ b/src/skidl/tools/kicad9/gen_schematic.py
@@ -594,6 +594,22 @@ def finalize_parts_and_nets(circuit, **options):
     rmv_attr(circuit.parts, ("force", "bbox", "lbl_bbox", "tx"))
 
 
+def _place_and_classify(node, circuit, expansion_factor, classify=True, **options):
+    """Place a node and, when auto_stub is on, run the stub classifiers.
+
+    Extracted so the main pass and the ERC-regeneration pass share one code
+    path. ``classify=False`` places without running ``_apply_deferred_stubs`` /
+    ``_classify_and_stub_complex_nets`` — used by the label-clearance re-place
+    pass, which must place against an already-frozen stub set (re-running the
+    classifiers would reset deferred pins and mutate the stub set after the
+    label-aware bboxes were computed).
+    """
+    node.place(expansion_factor=expansion_factor, **options)
+    if classify and options.get("auto_stub", False):
+        _apply_deferred_stubs(node, circuit, **options)
+        _classify_and_stub_complex_nets(circuit, node, **options)
+
+
 @export_to_all
 def gen_schematic(
     circuit,
@@ -697,10 +713,7 @@ def gen_schematic(
         )
 
         try:
-            node.place(expansion_factor=expansion_factor, **options)
-            if options.get("auto_stub", False):
-                _apply_deferred_stubs(node, circuit, **options)
-                _classify_and_stub_complex_nets(circuit, node, **options)
+            _place_and_classify(node, circuit, expansion_factor, **options)
             node.route(**options)
 
         except PlacementFailure as e:
@@ -770,10 +783,7 @@ def gen_schematic(
                             title,
                             flatness,
                         )
-                        node.place(expansion_factor=erc_expansion, **options)
-                        if options.get("auto_stub", False):
-                            _apply_deferred_stubs(node, circuit, **options)
-                            _classify_and_stub_complex_nets(circuit, node, **options)
+                        _place_and_classify(node, circuit, erc_expansion, **options)
                         node.route(**options)
                         if options.get("auto_stub", False):
                             _snap_two_pin_parts(node)

--- a/src/skidl/tools/kicad9/gen_schematic.py
+++ b/src/skidl/tools/kicad9/gen_schematic.py
@@ -714,6 +714,26 @@ def gen_schematic(
 
         try:
             _place_and_classify(node, circuit, expansion_factor, **options)
+            if options.get("auto_stub", False) and options.get("label_clearance", False):
+                # Label-clearance Pass 2: Pass 1's classifiers just froze the
+                # final stub set, but the placement they ran on reserved no room
+                # for the resulting net labels. Re-run preprocessing (recomputes
+                # each part's lbl_bbox to include the now-stubbed pins' label
+                # boxes) and rebuild the node (NetTerminals are derived from stub
+                # state, so the rebuild also clears stale terminals), then place
+                # WITHOUT reclassifying — classify=False keeps the stubs frozen.
+                # finalize first (as the ERC-regen path does before its rebuild):
+                # removes Pass-1 NetTerminals and clears force/bbox/lbl_bbox/tx so
+                # the rebuild starts clean. It does NOT touch pin.stub/net._stub,
+                # so the frozen stub set survives.
+                finalize_parts_and_nets(circuit, **options)
+                preprocess_circuit(circuit, **options)
+                node = SchNode(
+                    circuit, tool_module, filepath, top_name, title, flatness
+                )
+                _place_and_classify(
+                    node, circuit, expansion_factor, classify=False, **options
+                )
             node.route(**options)
 
         except PlacementFailure as e:

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -1370,6 +1370,22 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
                 ]
             )
         )
+    # Junction dots where the power-cap trunk taps each cap +ve pin / the IC
+    # connector, so the right-angle bus resolves as one connected net.
+    for jpt in getattr(node, "_power_cap_junctions", []):
+        jp = jpt * tx
+        jx, jy = _round_mm(jp.x), _round_mm(jp.y)
+        elements.append(
+            Sexp(
+                [
+                    "junction",
+                    ["at", jx, jy],
+                    ["diameter", 0],
+                    ["color", 0, 0, 0, 0],
+                    ["uuid", _gen_uuid(f"pcjunction:{jx}:{jy}")],
+                ]
+            )
+        )
     wired_pin_ids.update(getattr(node, "_power_cap_suppressed_pins", set()))
 
     # Generate net labels for stubbed pins (skip pins that got direct wires).

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -918,6 +918,26 @@ def _calc_sheet_tx(bbox):
 # ---------------------------------------------------------------------------
 
 
+def _power_lib_ids_in_elements(elements):
+    """Return the set of ``power:*`` lib_ids referenced by symbol instances in
+    ``elements``. Used to emit exactly the power-symbol definitions a sheet needs,
+    so every emitted power instance has a matching lib_symbols definition."""
+    found = set()
+    for el in elements:
+        if not (hasattr(el, "__getitem__") and len(el) and el[0] == "symbol"):
+            continue
+        for sub in el:
+            if (
+                hasattr(sub, "__getitem__")
+                and len(sub) >= 2
+                and sub[0] == "lib_id"
+                and isinstance(sub[1], str)
+                and sub[1].startswith("power:")
+            ):
+                found.add(sub[1])
+    return found
+
+
 @export_to_all
 def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
     """Convert a SchNode tree to S-expression schematic(s).
@@ -964,15 +984,11 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
             lib_id = f"{part.lib.filename}:{part.name}"
             lib_symbols[lib_id] = part
 
-    # Add power lib_symbols for any power symbols used in this sheet.
+    # Power-symbol definitions are emitted later from the instances actually
+    # placed on this sheet (see `_power_lib_ids_in_elements`), so no wire-based
+    # pre-scan is needed here. `pwr_symbols` is kept only to satisfy the
+    # flattened-node return contract.
     pwr_symbols = {}
-    for net in node.wires:
-        if net.name in pwr_symbol_names:
-            _used_power_symbols.add(net.name)
-    for pwr_name in _used_power_symbols:
-    # for pwr_name in sorted(_used_power_symbols):
-        pwr_lib_id = f"power:{pwr_name}"
-        pwr_symbols[pwr_lib_id] = pwr_name
 
     # Recurse into children.
     for i, child in enumerate(node.children.values()):
@@ -1038,10 +1054,16 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
     for part in lib_symbols.values():
         lib_symbols_sexp.append(Sexp(part_to_lib_symbol_definition(part)))
 
-    # Add S-expressions for any power symbols used in this sheet.
-    for id, pwr_name in pwr_symbols.items():
-        if id not in lib_symbols:
-            pwr_sexp = _extract_power_lib_symbol(pwr_name)
+    # Add power-symbol definitions. Derive these from the power-symbol INSTANCES
+    # actually emitted on this sheet (`elements`), NOT from `node.wires`: with
+    # auto_stub, power nets are stubbed (labels, not wires), so a wire-based scan
+    # misses them and the emitted instance has no definition -> KiCad reports an
+    # "unknown component". Scanning emitted instances guarantees every instance
+    # has a matching definition, and also covers power symbols contributed by
+    # flattened children (whose instances are already in `elements`).
+    for pwr_lib_id in sorted(_power_lib_ids_in_elements(elements)):
+        if pwr_lib_id not in lib_symbols:
+            pwr_sexp = _extract_power_lib_symbol(pwr_lib_id.split(":", 1)[1])
             if pwr_sexp:
                 lib_symbols_sexp.append(pwr_sexp)
 

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -1643,6 +1643,9 @@ def _deconflict_labels(elements, node, sheet_tx):
     def _cell(x, y):
         return (round(x / GRID), round(y / GRID))
 
+    def _on_grid(v):
+        return abs(v / GRID - round(v / GRID)) < 0.02
+
     # Component body bboxes in sheet (mm) coordinates.
     comp_bboxes = []
     for part in node.parts:
@@ -1696,6 +1699,11 @@ def _deconflict_labels(elements, node, sheet_tx):
         if at_sexp is None or len(at_sexp) < 4:
             continue
         lx, ly, langle = float(at_sexp[1]), float(at_sexp[2]), int(at_sexp[3])
+        # Only spread labels whose anchor (pin) is already on-grid, so the
+        # connecting wire has both ends on-grid (no added endpoint_off_grid
+        # warnings). Off-grid-pin labels are left in place.
+        if not (_on_grid(lx) and _on_grid(ly)):
+            continue
         dx, dy = _label_dir(langle)
         x_end, y_end = lx + dx * LABEL_W, ly + dy * LABEL_W
         lbl_bbox = BBox(

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -876,6 +876,70 @@ def _find_wireable_nets(node, tx, max_dist_mm=80.0):
     return wired_pin_ids, []
 
 
+def _render_xy(lx, ly, part_tx, sheet_tx):
+    """Transform a part-local point to KiCad render-mm (same convention as
+    _kicad_pin_pos, but for arbitrary points like bbox corners)."""
+    import math
+
+    angle_deg, mx, my = part_tx.analyze_transform()
+    composed = part_tx * sheet_tx
+    ox, oy = _round_mm(composed.origin.x), _round_mm(composed.origin.y)
+    px, py = lx, -ly
+    theta = math.radians(-angle_deg)
+    c, s = math.cos(theta), math.sin(theta)
+    rx, ry = px * c - py * s, px * s + py * c
+    if mx:
+        ry = -ry
+    if my:
+        rx = -rx
+    return _round_mm(ox + rx), _round_mm(oy + ry)
+
+
+def _part_render_bbox(part, sheet_tx):
+    """Axis-aligned (min, max) of a part's body in render-mm, or None."""
+    bbox = getattr(part, "place_bbox", None) or getattr(part, "lbl_bbox", None)
+    if bbox is None:
+        return None
+    pt = getattr(part, "tx", Tx())
+    corners = [
+        _render_xy(bbox.min.x, bbox.min.y, pt, sheet_tx),
+        _render_xy(bbox.max.x, bbox.min.y, pt, sheet_tx),
+        _render_xy(bbox.min.x, bbox.max.y, pt, sheet_tx),
+        _render_xy(bbox.max.x, bbox.max.y, pt, sheet_tx),
+    ]
+    xs = [c[0] for c in corners]
+    ys = [c[1] for c in corners]
+    return (min(xs), min(ys)), (max(xs), max(ys))
+
+
+def _seg_crosses_box(a, b, bmin, bmax, inset=0.5):
+    """True if segment a->b passes through the interior of box [bmin,bmax]
+    shrunk by `inset` mm (so a wire merely reaching a pin on the body edge
+    doesn't count — only a wire routed *through* the body). Liang-Barsky."""
+    xmin, ymin = bmin[0] + inset, bmin[1] + inset
+    xmax, ymax = bmax[0] - inset, bmax[1] - inset
+    if xmin >= xmax or ymin >= ymax:
+        return False
+    x1, y1 = a
+    dx, dy = b[0] - a[0], b[1] - a[1]
+    t0, t1 = 0.0, 1.0
+    for p, q in ((-dx, x1 - xmin), (dx, xmax - x1), (-dy, y1 - ymin), (dy, ymax - y1)):
+        if p == 0:
+            if q < 0:
+                return False
+        else:
+            r = q / p
+            if p < 0:
+                if r > t1:
+                    return False
+                t0 = max(t0, r)
+            else:
+                if r < t0:
+                    return False
+                t1 = min(t1, r)
+    return t0 <= t1
+
+
 def _gen_power_bus_wires(node, tx, max_gap_mm=10.0):
     """Generate wire segments connecting co-linear power net pins.
 
@@ -890,6 +954,16 @@ def _gen_power_bus_wires(node, tx, max_gap_mm=10.0):
     power_names = pwr_symbol_names
     bus_pin_ids = set()
     wires = []
+
+    # Part body bboxes in render-mm, so we can drop bus segments that would be
+    # routed straight through a component (the "wire crossing parts" clutter).
+    part_bodies = []
+    for _p in node.parts:
+        if isinstance(_p, NetTerminal):
+            continue
+        rb = _part_render_bbox(_p, tx)
+        if rb:
+            part_bodies.append((rb[0], rb[1], _p))
 
     seen_nets = set()
     for part in node.parts:
@@ -947,27 +1021,50 @@ def _gen_power_bus_wires(node, tx, max_gap_mm=10.0):
                         runs.append([sorted_group[j]])
                 return [r for r in runs if len(r) >= 3]
 
+            def _seg_clear(x1, y1, x2, y2, p1, p2):
+                """A bus segment is allowed only if it doesn't pass through a
+                part body other than the two pins it connects."""
+                for bmin, bmax, bp in part_bodies:
+                    if bp is p1.part or bp is p2.part:
+                        continue
+                    if _seg_crosses_box((x1, y1), (x2, y2), bmin, bmax):
+                        return False
+                return True
+
             def _emit_run(run, net_name):
+                # Split the run at any segment that would cross a part body, so
+                # those pins fall back to clean power symbols instead of a wire
+                # routed through a component. Each clean sub-run keeps wires +
+                # one power symbol (its last pin) for net identity.
+                subruns = [[run[0]]]
                 for j in range(len(run) - 1):
-                    x1, y1, _ = run[j]
-                    x2, y2, _ = run[j + 1]
-                    wires.append(
-                        Sexp(
-                            [
-                                "wire",
-                                ["pts", ["xy", x1, y1], ["xy", x2, y2]],
-                                ["stroke", ["width", 0], ["type", "default"]],
+                    x1, y1, p1 = run[j]
+                    x2, y2, p2 = run[j + 1]
+                    if _seg_clear(x1, y1, x2, y2, p1, p2):
+                        subruns[-1].append(run[j + 1])
+                    else:
+                        subruns.append([run[j + 1]])
+                for sub in subruns:
+                    if len(sub) < 2:
+                        continue  # isolated pin -> gets its own power symbol
+                    for j in range(len(sub) - 1):
+                        x1, y1, _ = sub[j]
+                        x2, y2, _ = sub[j + 1]
+                        wires.append(
+                            Sexp(
                                 [
-                                    "uuid",
-                                    _gen_uuid(
-                                        f"pbus:{net_name}:{x1}:{y1}:{x2}:{y2}"
-                                    ),
-                                ],
-                            ]
+                                    "wire",
+                                    ["pts", ["xy", x1, y1], ["xy", x2, y2]],
+                                    ["stroke", ["width", 0], ["type", "default"]],
+                                    [
+                                        "uuid",
+                                        _gen_uuid(f"pbus:{net_name}:{x1}:{y1}:{x2}:{y2}"),
+                                    ],
+                                ]
+                            )
                         )
-                    )
-                for _, _, p in run[:-1]:
-                    bus_pin_ids.add(id(p))
+                    for _, _, p in sub[:-1]:
+                        bus_pin_ids.add(id(p))
 
             # Process vertical groups (same X, split by Y gap).
             for x_key, group in x_groups.items():

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -1395,6 +1395,57 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
     # No-connect flags for NCNet pins.
     elements.extend(_gen_no_connect_flags(node, tx))
 
+    # Purge dangling wire remnants. Snap moves parts by reassigning part.tx,
+    # but a router wire to the old position can survive as a short stub whose
+    # far end touches nothing (KiCad flags these as wire_dangling). Drop any
+    # wire segment with an endpoint anchored to nothing — not a pin, label,
+    # junction, no-connect, or another wire endpoint. Iterate, since removing
+    # one stub can expose the next.
+    from collections import Counter as _Counter
+
+    _anchor_pts = set()
+    for _part in node.parts:
+        for _pin in _part:
+            _pp = getattr(_pin, "pt", Point(_pin.x, _pin.y))
+            _ptx = getattr(_pin.part, "tx", Tx())
+            _w = _pp * _ptx * tx
+            _anchor_pts.add((_round_mm(_w.x), _round_mm(_w.y)))
+    for _el in elements:
+        if isinstance(_el, (list, Sexp)) and len(_el) and _el[0] in (
+            "global_label", "label", "junction", "no_connect"
+        ):
+            for _s in _el:
+                if isinstance(_s, (list, Sexp)) and len(_s) >= 3 and _s[0] == "at":
+                    _anchor_pts.add((_s[1], _s[2]))
+                    break
+
+    def _wire_endpoints_of(_el):
+        for _s in _el:
+            if isinstance(_s, (list, Sexp)) and len(_s) and _s[0] == "pts":
+                return [
+                    (_xy[1], _xy[2])
+                    for _xy in _s[1:]
+                    if isinstance(_xy, (list, Sexp)) and len(_xy) >= 3 and _xy[0] == "xy"
+                ]
+        return []
+
+    for _ in range(8):  # iterate; cap as a safety backstop
+        _counts = _Counter()
+        _wires = []
+        for _i, _el in enumerate(elements):
+            if isinstance(_el, (list, Sexp)) and len(_el) and _el[0] == "wire":
+                _pts = _wire_endpoints_of(_el)
+                _wires.append((_i, _pts))
+                for _p in _pts:
+                    _counts[_p] += 1
+        _drop = set()
+        for _i, _pts in _wires:
+            if any(_p not in _anchor_pts and _counts.get(_p, 0) < 2 for _p in _pts):
+                _drop.add(_i)
+        if not _drop:
+            break
+        elements = [_el for _i, _el in enumerate(elements) if _i not in _drop]
+
     if node.flattened:
         # This node is flattened, so return elements for inclusion in the parent sheet.
         return elements, lib_symbols, pwr_symbols, ""

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -1623,13 +1623,25 @@ def _deconflict_labels(elements, node, sheet_tx):
     connection is preserved (in KiCad the label anchor IS the net connection
     point, so moving it without a wire would disconnect the pin).
 
-    Power symbols (``symbol`` elements) are never moved.
+    Safety at scale (dense auto-stub sheets): the nudged position is snapped to
+    the 50-mil grid, and a move is SKIPPED if its destination cell is already
+    occupied by a different net's label or by a wire endpoint — otherwise the
+    moved label / its wire endpoint could land on an unrelated element and
+    create a net short (ERC multiple_net_names / pin_to_pin). Power symbols are
+    never moved.
     """
     from math import cos, radians, sin
 
     from skidl.geometry import BBox
 
     MARGIN_MM = 1.27  # ~50 mils clearance from the body
+    GRID = 1.27       # KiCad 50-mil grid
+
+    def _snap(v):
+        return round(round(v / GRID) * GRID, 2)
+
+    def _cell(x, y):
+        return (round(x / GRID), round(y / GRID))
 
     # Component body bboxes in sheet (mm) coordinates.
     comp_bboxes = []
@@ -1649,6 +1661,24 @@ def _deconflict_labels(elements, node, sheet_tx):
     if not comp_bboxes:
         return
 
+    # Occupied grid cells: existing label anchors (keyed by net) and wire
+    # endpoints (net unknown -> never reuse). A move onto a cell owned by a
+    # different net is rejected.
+    occupied = {}
+    for elem in elements:
+        if not hasattr(elem, "__getitem__") or len(elem) < 1:
+            continue
+        if elem[0] == "global_label":
+            at = next((s for s in elem if hasattr(s, "__getitem__") and len(s) and s[0] == "at"), None)
+            if at and len(at) >= 3:
+                occupied[_cell(float(at[1]), float(at[2]))] = elem[1]
+        elif elem[0] == "wire":
+            pts = next((s for s in elem if hasattr(s, "__getitem__") and len(s) and s[0] == "pts"), None)
+            if pts:
+                for xy in pts[1:]:
+                    if hasattr(xy, "__getitem__") and len(xy) >= 3 and xy[0] == "xy":
+                        occupied[_cell(float(xy[1]), float(xy[2]))] = None
+
     def _label_dir(a):
         r = radians(a)
         return (cos(r), sin(r))
@@ -1658,6 +1688,7 @@ def _deconflict_labels(elements, node, sheet_tx):
     for elem in elements:
         if not hasattr(elem, "__getitem__") or len(elem) < 1 or elem[0] != "global_label":
             continue
+        net = elem[1]
         at_sexp = next(
             (s for s in elem if hasattr(s, "__getitem__") and len(s) > 0 and s[0] == "at"),
             None,
@@ -1677,22 +1708,28 @@ def _deconflict_labels(elements, node, sheet_tx):
             ax, ay = lx, ly  # original anchor (on the pin)
             if abs(dx) > abs(dy):
                 offset = (cb.max.x - lx + MARGIN_MM) if dx > 0 else (cb.min.x - lx - MARGIN_MM)
-                at_sexp[1] = _round_mm(lx + offset)
+                nx, ny = _snap(lx + offset), _snap(ly)
             else:
                 offset = (cb.max.y - ly + MARGIN_MM) if dy > 0 else (cb.min.y - ly - MARGIN_MM)
-                at_sexp[2] = _round_mm(ly + offset)
-            nx, ny = float(at_sexp[1]), float(at_sexp[2])
-            if (nx, ny) != (ax, ay):
-                new_wires.append(
-                    Sexp(
-                        [
-                            "wire",
-                            ["pts", ["xy", _round_mm(ax), _round_mm(ay)], ["xy", _round_mm(nx), _round_mm(ny)]],
-                            ["stroke", ["width", 0], ["type", "default"]],
-                            ["uuid", _gen_uuid(f"dcwire:{ax}:{ay}:{nx}:{ny}")],
-                        ]
-                    )
+                nx, ny = _snap(lx), _snap(ly + offset)
+            if (nx, ny) == (ax, ay):
+                break
+            # Reject moves that would collide with a different net or a wire end.
+            owner = occupied.get(_cell(nx, ny), "__free__")
+            if owner not in ("__free__", net):
+                break  # leave the label on its pin rather than risk a short
+            at_sexp[1], at_sexp[2] = nx, ny
+            occupied[_cell(nx, ny)] = net
+            new_wires.append(
+                Sexp(
+                    [
+                        "wire",
+                        ["pts", ["xy", _round_mm(ax), _round_mm(ay)], ["xy", nx, ny]],
+                        ["stroke", ["width", 0], ["type", "default"]],
+                        ["uuid", _gen_uuid(f"dcwire:{ax}:{ay}:{nx}:{ny}")],
+                    ]
                 )
+            )
             break  # resolve first overlap per label
     elements.extend(new_wires)
 

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -1518,6 +1518,9 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
             )
             hlabel_y += 2.54
 
+    # Spread net labels off component bodies (connectivity-preserving).
+    _deconflict_labels(elements, node, tx)
+
     # Add all the collected elements of the schematic.
     for elem in elements:
         schematic.append(elem)
@@ -1608,6 +1611,90 @@ def _validate_with_kicad_cli(filepath):
 # ---------------------------------------------------------------------------
 # File writer
 # ---------------------------------------------------------------------------
+
+
+def _deconflict_labels(elements, node, sheet_tx):
+    """Spread net labels that overlap component bodies, preserving connectivity.
+
+    Net labels initially sit on the pin endpoint. Where a label's text box
+    overlaps a component body, nudge the label outward along its direction axis
+    to clear the body (readability, like the v3 output), AND emit a short wire
+    from the original pin anchor to the moved label so the electrical
+    connection is preserved (in KiCad the label anchor IS the net connection
+    point, so moving it without a wire would disconnect the pin).
+
+    Power symbols (``symbol`` elements) are never moved.
+    """
+    from math import cos, radians, sin
+
+    from skidl.geometry import BBox
+
+    MARGIN_MM = 1.27  # ~50 mils clearance from the body
+
+    # Component body bboxes in sheet (mm) coordinates.
+    comp_bboxes = []
+    for part in node.parts:
+        if isinstance(part, NetTerminal):
+            continue
+        bbox = getattr(part, "place_bbox", None) or getattr(part, "lbl_bbox", None)
+        if bbox is None:
+            continue
+        tb = bbox * (getattr(part, "tx", Tx()) * sheet_tx)
+        comp_bboxes.append(
+            BBox(
+                Point(min(tb.min.x, tb.max.x), min(tb.min.y, tb.max.y)),
+                Point(max(tb.min.x, tb.max.x), max(tb.min.y, tb.max.y)),
+            )
+        )
+    if not comp_bboxes:
+        return
+
+    def _label_dir(a):
+        r = radians(a)
+        return (cos(r), sin(r))
+
+    LABEL_W, LABEL_H = 10.0, 2.0
+    new_wires = []
+    for elem in elements:
+        if not hasattr(elem, "__getitem__") or len(elem) < 1 or elem[0] != "global_label":
+            continue
+        at_sexp = next(
+            (s for s in elem if hasattr(s, "__getitem__") and len(s) > 0 and s[0] == "at"),
+            None,
+        )
+        if at_sexp is None or len(at_sexp) < 4:
+            continue
+        lx, ly, langle = float(at_sexp[1]), float(at_sexp[2]), int(at_sexp[3])
+        dx, dy = _label_dir(langle)
+        x_end, y_end = lx + dx * LABEL_W, ly + dy * LABEL_W
+        lbl_bbox = BBox(
+            Point(min(lx, x_end) - LABEL_H / 2, min(ly, y_end) - LABEL_H / 2),
+            Point(max(lx, x_end) + LABEL_H / 2, max(ly, y_end) + LABEL_H / 2),
+        )
+        for cb in comp_bboxes:
+            if not lbl_bbox.intersects(cb):
+                continue
+            ax, ay = lx, ly  # original anchor (on the pin)
+            if abs(dx) > abs(dy):
+                offset = (cb.max.x - lx + MARGIN_MM) if dx > 0 else (cb.min.x - lx - MARGIN_MM)
+                at_sexp[1] = _round_mm(lx + offset)
+            else:
+                offset = (cb.max.y - ly + MARGIN_MM) if dy > 0 else (cb.min.y - ly - MARGIN_MM)
+                at_sexp[2] = _round_mm(ly + offset)
+            nx, ny = float(at_sexp[1]), float(at_sexp[2])
+            if (nx, ny) != (ax, ay):
+                new_wires.append(
+                    Sexp(
+                        [
+                            "wire",
+                            ["pts", ["xy", _round_mm(ax), _round_mm(ay)], ["xy", _round_mm(nx), _round_mm(ny)]],
+                            ["stroke", ["width", 0], ["type", "default"]],
+                            ["uuid", _gen_uuid(f"dcwire:{ax}:{ay}:{nx}:{ny}")],
+                        ]
+                    )
+                )
+            break  # resolve first overlap per label
+    elements.extend(new_wires)
 
 
 def _write_sexp_schematic(schematic, filepath):

--- a/src/skidl/tools/kicad9/sexp_schematic.py
+++ b/src/skidl/tools/kicad9/sexp_schematic.py
@@ -25,6 +25,7 @@ from collections import OrderedDict
 from simp_sexp import Sexp
 
 from skidl.geometry import Point, Tx
+from skidl.net import NCNet
 from skidl.pckg_info import __version__
 from skidl.schematics.net_terminal import NetTerminal
 from skidl.schlib import SchLib
@@ -693,7 +694,10 @@ def net_label_to_sexp(pin, tx=Tx(), force=False):
     """
     if not force and (not pin.stub or not pin.is_connected()):
         return None
-    
+
+    if isinstance(getattr(pin, "net", None), NCNet):
+        return None
+
     # Check if this net matches a known KiCad power symbol.
     # If so, emit a power symbol instance instead of a global_label.
     # This eliminates power_pin_not_driven ERC errors.
@@ -730,6 +734,285 @@ def net_label_to_sexp(pin, tx=Tx(), force=False):
     )
 
     return label
+
+
+# ---------------------------------------------------------------------------
+# Snap-aware emitters: label suppression, power buses, no-connect flags
+# ---------------------------------------------------------------------------
+
+
+def _kicad_pin_pos(pin, part_tx, sheet_tx):
+    """Compute pin position as KiCad renders it from symbol placement.
+
+    KiCad's pin transform order: Y-flip, rotate(-angle), then mirror.
+    The angle from analyze_transform() is the visual angle in SKiDL's Y-up
+    space; KiCad uses its negative because the sheet Y-flip reverses rotation.
+    """
+    import math
+
+    angle_deg, mx, my = part_tx.analyze_transform()
+    composed = part_tx * sheet_tx
+    ox = _round_mm(composed.origin.x)
+    oy = _round_mm(composed.origin.y)
+
+    px, py = pin.x, -pin.y
+
+    theta = math.radians(-angle_deg)
+    cos_t, sin_t = math.cos(theta), math.sin(theta)
+    rx = px * cos_t - py * sin_t
+    ry = px * sin_t + py * cos_t
+
+    if mx:
+        ry = -ry
+    if my:
+        rx = -rx
+
+    return _round_mm(ox + rx), _round_mm(oy + ry)
+
+
+def _find_wireable_nets(node, tx, max_dist_mm=80.0):
+    """Suppress labels for pins connected by snap (overlapping positions).
+
+    Builds connected clusters of overlapping pins per net. Within each
+    cluster, all pins are physically connected so only one label is needed
+    (for cross-sheet connectivity). All other pins in the cluster are
+    suppressed.
+
+    Returns:
+        tuple: (wired_pin_ids, wire_sexps) where wired_pin_ids is a set of
+            id(pin) for pins that should NOT get labels, and wire_sexps is
+            an empty list (no wire elements needed for overlapping pins).
+    """
+    node_part_ids = {id(p) for p in node.parts}
+    wired_pin_ids = set()
+
+    seen_nets = set()
+    for part in node.parts:
+        if isinstance(part, NetTerminal):
+            continue
+        for pin in part:
+            if not pin.stub or not pin.is_connected():
+                continue
+            net = pin.net
+            if id(net) in seen_nets:
+                continue
+            seen_nets.add(id(net))
+
+            is_power = net.name in pwr_symbol_names
+
+            # For non-power nets, only consider stubbed pins (these get labels).
+            # For power nets, consider ALL pins on this sheet — power symbols
+            # are emitted regardless of stub state, so we still want to suppress
+            # redundant ones when pins overlap (cap snap-stacked on IC VCC pin).
+            if is_power:
+                pins_in_node = [
+                    p for p in net.pins
+                    if id(p.part) in node_part_ids
+                    and not isinstance(p.part, NetTerminal)
+                ]
+            else:
+                pins_in_node = [
+                    p for p in net.pins
+                    if id(p.part) in node_part_ids
+                    and not isinstance(p.part, NetTerminal)
+                    and p.stub
+                ]
+            if len(pins_in_node) < 2:
+                continue
+
+            positions = []
+            for p in pins_in_node:
+                x, y = _kicad_pin_pos(p, getattr(p.part, "tx", Tx()), tx)
+                positions.append((x, y, p))
+
+            # Union-find to cluster overlapping pins (dist < 0.01mm).
+            parent = list(range(len(positions)))
+
+            def find(i):
+                while parent[i] != i:
+                    parent[i] = parent[parent[i]]
+                    i = parent[i]
+                return i
+
+            for i in range(len(positions)):
+                for j in range(i + 1, len(positions)):
+                    dist = ((positions[i][0] - positions[j][0]) ** 2 +
+                            (positions[i][1] - positions[j][1]) ** 2) ** 0.5
+                    if dist < 0.01:
+                        ri, rj = find(i), find(j)
+                        if ri != rj:
+                            parent[ri] = rj
+
+            # Group pins by cluster.
+            clusters = {}
+            for i in range(len(positions)):
+                r = find(i)
+                clusters.setdefault(r, []).append(i)
+
+            # Check if the net has pins outside this sheet.
+            all_real_pins = [
+                p for p in net.pins
+                if not isinstance(p.part, NetTerminal)
+            ]
+            has_pins_outside = len(all_real_pins) > len(pins_in_node)
+
+            for members in clusters.values():
+                if len(members) < 2:
+                    continue
+
+                pins_outside_cluster = len(pins_in_node) - len(members)
+
+                if not has_pins_outside and pins_outside_cluster == 0:
+                    # All net pins are in this cluster — fully connected by
+                    # overlap, no labels needed at all.
+                    for idx in members:
+                        wired_pin_ids.add(id(positions[idx][2]))
+                else:
+                    # Net has pins elsewhere — keep one label for cross-sheet
+                    # connectivity, suppress the rest.
+                    for idx in members[1:]:
+                        wired_pin_ids.add(id(positions[idx][2]))
+
+    return wired_pin_ids, []
+
+
+def _gen_power_bus_wires(node, tx, max_gap_mm=10.0):
+    """Generate wire segments connecting co-linear power net pins.
+
+    Finds subgroups of 3+ pins on the same power net that share an X or Y
+    coordinate (within 0.1mm) AND are spaced within max_gap_mm of each
+    neighbour. Returns (wire_sexps, bus_pin_ids) where bus_pin_ids are
+    pins that should NOT get individual power symbols.
+    """
+    from collections import defaultdict
+
+    node_part_ids = {id(p) for p in node.parts}
+    power_names = pwr_symbol_names
+    bus_pin_ids = set()
+    wires = []
+
+    seen_nets = set()
+    for part in node.parts:
+        if isinstance(part, NetTerminal):
+            continue
+        for pin in part:
+            if not pin.is_connected():
+                continue
+            net = pin.net
+            if id(net) in seen_nets:
+                continue
+            seen_nets.add(id(net))
+
+            if net.name not in power_names:
+                continue
+
+            pins_in_node = [
+                p for p in net.pins
+                if id(p.part) in node_part_ids
+                and not isinstance(p.part, NetTerminal)
+                and len(p.part.pins) == 2
+                and not all(
+                    pp.is_connected() and pp.net.name in power_names
+                    for pp in p.part.pins
+                )
+            ]
+            if len(pins_in_node) < 3:
+                continue
+
+            positions = []
+            for p in pins_in_node:
+                x, y = _kicad_pin_pos(p, getattr(p.part, "tx", Tx()), tx)
+                positions.append((_round_mm(x), _round_mm(y), p))
+
+            # Group pins by shared X coordinate (vertical columns).
+            x_groups = defaultdict(list)
+            for pos in positions:
+                x_key = round(pos[0], 1)
+                x_groups[x_key].append(pos)
+
+            # Group pins by shared Y coordinate (horizontal rows).
+            y_groups = defaultdict(list)
+            for pos in positions:
+                y_key = round(pos[1], 1)
+                y_groups[y_key].append(pos)
+
+            def _split_runs(sorted_group, axis):
+                """Split sorted positions into contiguous runs by max_gap_mm."""
+                runs = [[sorted_group[0]]]
+                for j in range(1, len(sorted_group)):
+                    gap = abs(sorted_group[j][axis] - sorted_group[j - 1][axis])
+                    if gap <= max_gap_mm:
+                        runs[-1].append(sorted_group[j])
+                    else:
+                        runs.append([sorted_group[j]])
+                return [r for r in runs if len(r) >= 3]
+
+            def _emit_run(run, net_name):
+                for j in range(len(run) - 1):
+                    x1, y1, _ = run[j]
+                    x2, y2, _ = run[j + 1]
+                    wires.append(
+                        Sexp(
+                            [
+                                "wire",
+                                ["pts", ["xy", x1, y1], ["xy", x2, y2]],
+                                ["stroke", ["width", 0], ["type", "default"]],
+                                [
+                                    "uuid",
+                                    _gen_uuid(
+                                        f"pbus:{net_name}:{x1}:{y1}:{x2}:{y2}"
+                                    ),
+                                ],
+                            ]
+                        )
+                    )
+                for _, _, p in run[:-1]:
+                    bus_pin_ids.add(id(p))
+
+            # Process vertical groups (same X, split by Y gap).
+            for x_key, group in x_groups.items():
+                if len(group) < 3:
+                    continue
+                group.sort(key=lambda p: p[1])
+                for run in _split_runs(group, axis=1):
+                    _emit_run(run, net.name)
+
+            # Process horizontal groups (same Y, split by X gap).
+            for y_key, group in y_groups.items():
+                if len(group) < 3:
+                    continue
+                group.sort(key=lambda p: p[0])
+                for run in _split_runs(group, axis=0):
+                    _emit_run(run, net.name)
+
+    return wires, bus_pin_ids
+
+
+def _gen_no_connect_flags(node, tx):
+    """Generate no_connect flag S-expressions for pins on NCNet.
+
+    Returns a list of Sexp objects, one per NC pin.
+    """
+    flags = []
+    for part in node.parts:
+        if isinstance(part, NetTerminal):
+            continue
+        for pin in part:
+            if not isinstance(getattr(pin, "net", None), NCNet):
+                continue
+            pin_pt = getattr(pin, "pt", Point(pin.x, pin.y))
+            part_tx = getattr(pin.part, "tx", Tx())
+            pt = pin_pt * part_tx * tx
+            flags.append(
+                Sexp(
+                    [
+                        "no_connect",
+                        ["at", _round_mm(pt.x), _round_mm(pt.y)],
+                        ["uuid", _gen_uuid(f"nc:{part.ref}:{pin.num}:{pt.x}:{pt.y}")],
+                    ]
+                )
+            )
+    return flags
 
 
 # ---------------------------------------------------------------------------
@@ -1001,33 +1284,116 @@ def node_to_sexp_schematic(node, uuid_path, sheet_tx=Tx(), version=20230409):
         lib_symbols.update(part_dict)
         pwr_symbols.update(pwr_dict)
 
+    # Collect net names that have real (non-NetTerminal) stubbed pins on this
+    # sheet.  NetTerminal labels are redundant for these nets since the pins
+    # will generate their own labels.
+    nets_with_real_pins = set()
+    for part in node.parts:
+        if isinstance(part, NetTerminal):
+            continue
+        for pin in part:
+            if pin.stub and pin.is_connected():
+                nets_with_real_pins.add(pin.net.name)
+
     # Generate part S-expressions.
     for part in node.parts:
         if isinstance(part, NetTerminal):
-            # NetTerminals become net labels.
-            label = net_label_to_sexp(part.pins[0], tx=tx, force=True)
+            # NetTerminals become net labels (unless a real pin already labels the net).
+            pin = part.pins[0]
+            if pin.is_connected() and pin.net.name in nets_with_real_pins:
+                continue
+            label = net_label_to_sexp(pin, tx=tx, force=True)
             if label:
                 elements.append(label)
         else:
             elements.append(part_to_sexp(part, uuid_path, tx=tx))
 
     # Generate wire S-expressions (split at junction points).
+    # Skip nets that snap converted to stubs after routing — their routed
+    # geometry is stale now that the parts moved, so they use labels instead.
     for net, wire in node.wires.items():
+        if getattr(net, "_stub", False):
+            continue
         net_junctions = node.junctions.get(net, [])
         elements.extend(wire_to_sexp(net, wire, tx=tx, junctions=net_junctions))
 
     # Generate junction S-expressions.
     for net, junctions in node.junctions.items():
+        if getattr(net, "_stub", False):
+            continue
         elements.extend(junction_to_sexp(net, junctions, tx=tx))
 
-    # Generate net labels for stubbed pins.
+    # Suppress labels for snap-overlapping pins (one label per connected cluster).
+    wired_pin_ids, direct_wires = _find_wireable_nets(node, tx)
+    elements.extend(direct_wires)
+
+    # Connect co-linear power net pins with bus wires.
+    power_wires, bus_pin_ids = _gen_power_bus_wires(node, tx)
+    elements.extend(power_wires)
+    wired_pin_ids.update(bus_pin_ids)
+
+    # Generate T-junction wires from staggered snap placement.
+    for tjw in getattr(node, "_tjunction_wires", []):
+        x1_mil, y1_mil, x2_mil, y2_mil = tjw
+        p1 = Point(x1_mil, y1_mil) * tx
+        p2 = Point(x2_mil, y2_mil) * tx
+        x1, y1 = _round_mm(p1.x), _round_mm(p1.y)
+        x2, y2 = _round_mm(p2.x), _round_mm(p2.y)
+        elements.append(
+            Sexp(
+                [
+                    "wire",
+                    ["pts", ["xy", x1, y1], ["xy", x2, y2]],
+                    ["stroke", ["width", 0], ["type", "default"]],
+                    ["uuid", _gen_uuid(f"tjwire:{x1}:{y1}:{x2}:{y2}")],
+                ]
+            )
+        )
+    # Suppress labels for staggered T-junction signal pins (connected by wire).
+    wired_pin_ids.update(getattr(node, "_tjunction_suppressed_pins", set()))
+
+    # Emit wires for decoupling caps offset-snapped to IC power pins, and
+    # suppress their pin labels (the wire makes the redundant label noise).
+    for pcw in getattr(node, "_power_cap_wires", []):
+        x1_mil, y1_mil, x2_mil, y2_mil = pcw
+        p1 = Point(x1_mil, y1_mil) * tx
+        p2 = Point(x2_mil, y2_mil) * tx
+        x1, y1 = _round_mm(p1.x), _round_mm(p1.y)
+        x2, y2 = _round_mm(p2.x), _round_mm(p2.y)
+        elements.append(
+            Sexp(
+                [
+                    "wire",
+                    ["pts", ["xy", x1, y1], ["xy", x2, y2]],
+                    ["stroke", ["width", 0], ["type", "default"]],
+                    ["uuid", _gen_uuid(f"pcwire:{x1}:{y1}:{x2}:{y2}")],
+                ]
+            )
+        )
+    wired_pin_ids.update(getattr(node, "_power_cap_suppressed_pins", set()))
+
+    # Generate net labels for stubbed pins (skip pins that got direct wires).
     for part in node.parts:
         if isinstance(part, NetTerminal):
             continue
         for pin in part:
+            if id(pin) in wired_pin_ids:
+                continue
             label = net_label_to_sexp(pin, tx=tx)
             if label:
                 elements.append(label)
+            elif (
+                len(part.pins) == 2
+                and not pin.stub
+                and pin.is_connected()
+                and pin.net.name in pwr_symbol_names
+            ):
+                label = net_label_to_sexp(pin, tx=tx, force=True)
+                if label:
+                    elements.append(label)
+
+    # No-connect flags for NCNet pins.
+    elements.extend(_gen_no_connect_flags(node, tx))
 
     if node.flattened:
         # This node is flattened, so return elements for inclusion in the parent sheet.

--- a/tests/unit_tests/ai_tests/test_auto_stub.py
+++ b/tests/unit_tests/ai_tests/test_auto_stub.py
@@ -118,12 +118,16 @@ class TestAutoStubNets:
         auto_stub_nets(circuit)
         assert net._stub is False
 
-    def test_high_fanout_stubbed(self):
-        """Net with 6 pins (above default threshold 5) gets stubbed."""
+    def test_high_fanout_deferred(self):
+        """Net with 6 pins (above default threshold 5) is marked for DEFERRED
+        stubbing: kept connected during placement (for grouping), stubbed after
+        placement via _apply_deferred_stubs. So _stub stays False here and
+        _deferred_stub is set."""
         net = self._make_mock_net("BUS_DATA", pin_count=6)
         circuit = self._make_mock_circuit([net])
         auto_stub_nets(circuit)
-        assert net._stub is True
+        assert getattr(net, "_deferred_stub", False) is True
+        assert net._stub is False  # not stubbed until after placement
 
     def test_low_fanout_not_stubbed(self):
         """Net with 3 pins (below threshold) stays wired."""
@@ -133,11 +137,12 @@ class TestAutoStubNets:
         assert net._stub is False
 
     def test_custom_fanout_threshold(self):
-        """Custom fanout threshold is respected."""
+        """Custom fanout threshold is respected (deferred marking)."""
         net = self._make_mock_net("SIG", pin_count=3)
         circuit = self._make_mock_circuit([net])
         auto_stub_nets(circuit, auto_stub_fanout=3)
-        assert net._stub is True
+        assert getattr(net, "_deferred_stub", False) is True
+        assert net._stub is False  # deferred until after placement
 
     def test_explicit_override_respected(self):
         """User-explicit stub=False on GND stays wired."""

--- a/tests/unit_tests/ai_tests/test_auto_stub.py
+++ b/tests/unit_tests/ai_tests/test_auto_stub.py
@@ -703,3 +703,124 @@ class TestHierarchicalLabels:
         assert "hierarchical_label" in label_str
         assert "TEST_NET" in label_str
         assert "bidirectional" in label_str
+
+
+@requires_kicad_libs
+class TestSharedIcPinFan:
+    """Two 2-pin parts sharing ONE IC pin must fan out as a T-junction.
+
+    Regression for the ESP32 EN-pin bug: a pull-up R (to VCC) plus a filter
+    cap (to GND) both land on the MCU's EN/reset pin. The first part tees off
+    the pin fine, but the second used to chain colinearly back across the IC
+    body instead of staggering out, overlapping the symbol. A single shared IC
+    pin with >= 2 two-pin parts must trigger the same staggered fan that a row
+    of repeated IC-pin fans (e.g. 74HC165 switch + pull-down inputs) does.
+    """
+
+    def _snap_geometry_for_ic_pin(self, output_dir):
+        """Build IC + pull-up + cap on one pin; capture post-snap geometry.
+
+        Returns (tjunction_wire_count, parts_by_ref) for the node holding the
+        IC, captured at the final snap call (after placement/routing).
+        """
+        import importlib as _il
+        from skidl import Circuit, Net, Part
+        from skidl.geometry import Point
+        from skidl.schematics import snap as snap_mod
+
+        captured = {}
+        orig = snap_mod.snap_two_pin_parts
+
+        def _traced(node):
+            refs = [getattr(p, "ref", "") for p in node.parts]
+            orig(node)
+            # The node that owns the multi-pin IC (an op-amp here) is the one
+            # we care about; keep overwriting so we end up with the final
+            # (fully-placed) snap pass.
+            if any(len(getattr(p, "pins", [])) > 2 for p in node.parts):
+                geo = {
+                    "tj_wires": list(getattr(node, "_tjunction_wires", [])),
+                    "parts": {},
+                }
+                for p in node.parts:
+                    pins = []
+                    for pin in p.pins:
+                        w = pin.pt * p.tx
+                        net = getattr(pin, "net", None)
+                        pins.append(
+                            (getattr(pin, "num", "?"),
+                             net.name if net else None,
+                             round(w.x), round(w.y))
+                        )
+                    geo["parts"][getattr(p, "ref", "?")] = pins
+                captured["geo"] = geo
+
+        snap_mod.snap_two_pin_parts = _traced
+        # gen_schematic imported the symbol by value — patch its reference too.
+        gs = _il.import_module(f"skidl.tools.{get_default_tool()}.gen_schematic")
+        gs_orig = gs._snap_two_pin_parts
+        gs._snap_two_pin_parts = _traced
+        try:
+            circuit = Circuit(name="shared_pin_fan")
+            with circuit:
+                # Op-amp: a small multi-pin IC available in every KiCad install.
+                opamp = Part("Amplifier_Operational", "LM358", value="LM358")
+                vcc = Net("VCC")
+                gnd = Net("GND")
+                en = Net("EN")
+                # Drive the op-amp's other pins so it places sensibly.
+                opamp[8] += vcc
+                opamp[4] += gnd
+                # Share ONE IC pin (pin 3, +IN) between a pull-up and a cap.
+                opamp[3] += en
+                r_en = Part("Device", "R", value="10K")
+                r_en[1] += vcc
+                r_en[2] += en
+                c_en = Part("Device", "C", value="100nF")
+                c_en[1] += en
+                c_en[2] += gnd
+                circuit.generate_schematic(
+                    filepath=output_dir, top_name="shared_pin_fan",
+                    auto_stub=True,
+                )
+        finally:
+            snap_mod.snap_two_pin_parts = orig
+            gs._snap_two_pin_parts = gs_orig
+
+        assert "geo" in captured, "snap never ran on a node containing the IC"
+        return captured["geo"]
+
+    def test_shared_ic_pin_emits_tjunction_wire(self, output_dir):
+        """The shared IC pin gets a drawn T-junction wire (not a label-only stub)."""
+        geo = self._snap_geometry_for_ic_pin(output_dir)
+        assert geo["tj_wires"], (
+            "expected a T-junction wire off the shared IC pin; got none "
+            "(the fan fell back to a colinear chain)"
+        )
+
+    def test_shared_ic_pin_parts_stagger_apart(self, output_dir):
+        """R and C don't stack on the same line: their free pins differ in the
+        axis perpendicular to the IC pin, i.e. one fans up and one fans down."""
+        geo = self._snap_geometry_for_ic_pin(output_dir)
+        parts = geo["parts"]
+        assert "R1" in parts and "C1" in parts, parts.keys()
+
+        def free_pin(pin_list):
+            # the pin NOT on the shared EN net is the part's free (VCC/GND) pin
+            for num, net, x, y in pin_list:
+                if net != "EN":
+                    return x, y
+            return None
+
+        rx, ry = free_pin(parts["R1"])
+        cx, cy = free_pin(parts["C1"])
+        # Staggered fan => the two free pins separate along one axis; they must
+        # not coincide (which is what the colinear-overlap bug produced).
+        assert (rx, ry) != (cx, cy), (
+            f"R and C free pins coincide ({rx},{ry}) — not staggered"
+        )
+        # And they fan to opposite sides: separated on exactly one axis by a
+        # meaningful amount (perp_dir vs anti_perp).
+        assert (abs(rx - cx) > 100) or (abs(ry - cy) > 100), (
+            f"R free pin ({rx},{ry}) and C free pin ({cx},{cy}) too close"
+        )

--- a/tests/unit_tests/ai_tests/test_dev_base_fixes.py
+++ b/tests/unit_tests/ai_tests/test_dev_base_fixes.py
@@ -17,6 +17,7 @@ import glob
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 
 import pytest
@@ -90,57 +91,38 @@ def test_power_symbol_defs_complete_under_autostub(output_dir):
     assert not missing, f"power symbols emitted without definitions: {missing}"
 
 
-# KiCad global_label angle -> the unit vector the label text extends along.
-_ANGLE_VEC = {0: (1, 0), 90: (0, 1), 180: (-1, 0), 270: (0, -1)}
 
 
-def _labels_pointing_into_parts(output_dir, threshold=-0.3):
-    """Bug 2 guard (coarse): a net label must not point back INTO the body of the
-    part it sits on. This catches gross orientation flips (e.g. a bad orient_map
-    or a deconfliction anchor-move), NOT subtle/aesthetic angle preferences —
-    those need a visual check and are the maintainer's domain.
+HAS_KICAD_CLI = shutil.which("kicad-cli") is not None
+requires_kicad_cli = pytest.mark.skipif(
+    not HAS_KICAD_CLI, reason="kicad-cli not installed"
+)
 
-    Returns list of (sheet, net, angle, dot) for labels pointing into a part.
-    """
-    import math
-    bad = []
-    for f in glob.glob(os.path.join(output_dir, "**", "*.kicad_sch"), recursive=True):
-        txt = open(f).read()
-        syms = [
-            (float(m.group(2)), float(m.group(3)))
-            for m in re.finditer(
-                r'\(symbol\s+\(lib_id "([^"]+)"\)\s*\(at ([\d.\-]+) ([\d.\-]+) ([\d.\-]+)\)',
-                txt,
-            )
-            if not m.group(1).startswith("power:")
-        ]
-        labels = [
-            (m.group(1), float(m.group(2)), float(m.group(3)), float(m.group(4)))
-            for m in re.finditer(
-                r'\(global_label "([^"]+)"\s*\(shape \w+\)\s*\(at ([\d.\-]+) ([\d.\-]+) ([\d.\-]+)\)',
-                txt,
-            )
-        ]
-        if not syms or not labels:
-            continue
-        for name, lx, ly, la in labels:
-            sx, sy = min(syms, key=lambda s: (s[0] - lx) ** 2 + (s[1] - ly) ** 2)
-            ox, oy = lx - sx, ly - sy
-            n = math.hypot(ox, oy) or 1.0
-            ox, oy = ox / n, oy / n
-            vx, vy = _ANGLE_VEC.get(int(la) % 360, (0, 0))
-            dot = ox * vx + oy * vy
-            if dot <= threshold:
-                bad.append((os.path.basename(f), name, int(la), round(dot, 2)))
-    return bad
+
+def _erc_connectivity_violations(sch_path):
+    """Run kicad-cli ERC and return connectivity-class violations (pins/wires
+    left unconnected). Excludes semantic warnings (pin_not_driven from netio)
+    and environmental lib-config warnings."""
+    rpt = sch_path.replace(".kicad_sch", "-conn-erc.rpt")
+    subprocess.run(
+        ["kicad-cli", "sch", "erc", "--output", rpt, "--severity-all", sch_path],
+        capture_output=True, timeout=60,
+    )
+    if not os.path.exists(rpt):
+        return []
+    txt = open(rpt).read()
+    bad_types = ("pin_not_connected", "unconnected", "endpoint", "dangling", "wire_dangling")
+    return [t for t in bad_types if f"[{t}]" in txt]
 
 
 @requires_kicad_libs
-def test_net_labels_do_not_point_into_parts(output_dir):
-    """Coarse orientation guard across mirrored/rotated parts: no net label points
-    into the body of its part. (Fine orientation/justification is visual and not
-    asserted here.)"""
-    from skidl import Net, Part, TEMPLATE, generate_schematic
+@requires_kicad_cli
+def test_deconflicted_labels_stay_connected(output_dir):
+    """Label deconfliction spreads net labels off component bodies for
+    readability, but must preserve connectivity: each moved label is wired back
+    to its pin. Across mirrored/rotated parts, ERC must report no
+    connectivity-class violations (unconnected pins / dangling wire ends)."""
+    from skidl import Net, Part, TEMPLATE
 
     circuit = Circuit(name="bjt_orient")
     with circuit:
@@ -154,5 +136,6 @@ def test_net_labels_do_not_point_into_parts(output_dir):
             q.symtx = tx
         circuit.generate_schematic(filepath=output_dir, top_name="bjt_orient", flatness=1.0)
 
-    bad = _labels_pointing_into_parts(output_dir)
-    assert not bad, f"labels pointing into their part: {bad}"
+    sch = os.path.join(output_dir, "bjt_orient.kicad_sch")
+    violations = _erc_connectivity_violations(sch)
+    assert not violations, f"deconfliction left connectivity violations: {violations}"

--- a/tests/unit_tests/ai_tests/test_dev_base_fixes.py
+++ b/tests/unit_tests/ai_tests/test_dev_base_fixes.py
@@ -88,3 +88,71 @@ def test_power_symbol_defs_complete_under_autostub(output_dir):
     )
     missing = _power_symbol_integrity(output_dir)
     assert not missing, f"power symbols emitted without definitions: {missing}"
+
+
+# KiCad global_label angle -> the unit vector the label text extends along.
+_ANGLE_VEC = {0: (1, 0), 90: (0, 1), 180: (-1, 0), 270: (0, -1)}
+
+
+def _labels_pointing_into_parts(output_dir, threshold=-0.3):
+    """Bug 2 guard (coarse): a net label must not point back INTO the body of the
+    part it sits on. This catches gross orientation flips (e.g. a bad orient_map
+    or a deconfliction anchor-move), NOT subtle/aesthetic angle preferences —
+    those need a visual check and are the maintainer's domain.
+
+    Returns list of (sheet, net, angle, dot) for labels pointing into a part.
+    """
+    import math
+    bad = []
+    for f in glob.glob(os.path.join(output_dir, "**", "*.kicad_sch"), recursive=True):
+        txt = open(f).read()
+        syms = [
+            (float(m.group(2)), float(m.group(3)))
+            for m in re.finditer(
+                r'\(symbol\s+\(lib_id "([^"]+)"\)\s*\(at ([\d.\-]+) ([\d.\-]+) ([\d.\-]+)\)',
+                txt,
+            )
+            if not m.group(1).startswith("power:")
+        ]
+        labels = [
+            (m.group(1), float(m.group(2)), float(m.group(3)), float(m.group(4)))
+            for m in re.finditer(
+                r'\(global_label "([^"]+)"\s*\(shape \w+\)\s*\(at ([\d.\-]+) ([\d.\-]+) ([\d.\-]+)\)',
+                txt,
+            )
+        ]
+        if not syms or not labels:
+            continue
+        for name, lx, ly, la in labels:
+            sx, sy = min(syms, key=lambda s: (s[0] - lx) ** 2 + (s[1] - ly) ** 2)
+            ox, oy = lx - sx, ly - sy
+            n = math.hypot(ox, oy) or 1.0
+            ox, oy = ox / n, oy / n
+            vx, vy = _ANGLE_VEC.get(int(la) % 360, (0, 0))
+            dot = ox * vx + oy * vy
+            if dot <= threshold:
+                bad.append((os.path.basename(f), name, int(la), round(dot, 2)))
+    return bad
+
+
+@requires_kicad_libs
+def test_net_labels_do_not_point_into_parts(output_dir):
+    """Coarse orientation guard across mirrored/rotated parts: no net label points
+    into the body of its part. (Fine orientation/justification is visual and not
+    asserted here.)"""
+    from skidl import Net, Part, TEMPLATE, generate_schematic
+
+    circuit = Circuit(name="bjt_orient")
+    with circuit:
+        e, b, c = Net("ENET"), Net("BNET"), Net("CNET")
+        b.netio = "i"
+        e.stub, b.stub, c.stub = True, True, True
+        qt = Part(lib="Transistor_BJT", name="Q_PNP_CBE", dest=TEMPLATE)
+        for q, tx in zip(qt(8), ["", "H", "V", "R", "L", "VL", "HR", "LV"]):
+            q["E B C"] += e, b, c
+            q.ref = "Q_" + tx
+            q.symtx = tx
+        circuit.generate_schematic(filepath=output_dir, top_name="bjt_orient", flatness=1.0)
+
+    bad = _labels_pointing_into_parts(output_dir)
+    assert not bad, f"labels pointing into their part: {bad}"

--- a/tests/unit_tests/ai_tests/test_dev_base_fixes.py
+++ b/tests/unit_tests/ai_tests/test_dev_base_fixes.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+"""Regression tests for bugs in the `development` schematic backend, found while
+designing the snap backend split (see ARCHITECTURE-snap-backend-split.md).
+
+Bug 1 (missing symbols): power-symbol *definitions* were scoped per-sheet from
+`node.wires`, but power-symbol *instances* are emitted from power-net pins. With
+auto_stub, power nets are stubbed (labels, not wires), so instances were emitted
+on child sheets with no matching lib_symbols definition -> KiCad "unknown
+component".
+
+Bug 2 (label orientation): net-label angle must follow the pin's *rendered*
+direction (after the sheet Y-flip), not the abstract pin direction.
+"""
+
+import glob
+import os
+import re
+import shutil
+import tempfile
+
+import pytest
+from skidl import Circuit, Net, Part, Interface, subcircuit
+
+HAS_KICAD_LIBS = os.path.isdir(
+    os.getenv("KICAD9_SYMBOL_DIR", "/usr/share/kicad/symbols")
+)
+requires_kicad_libs = pytest.mark.skipif(
+    not HAS_KICAD_LIBS, reason="KiCad 9 symbol libraries not installed"
+)
+
+
+@pytest.fixture
+def output_dir():
+    d = tempfile.mkdtemp(prefix="skidl_dev_base_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _power_symbol_integrity(output_dir):
+    """Map {sheet_filename: [power lib_ids emitted as instances with no def]}."""
+    result = {}
+    for f in glob.glob(os.path.join(output_dir, "**", "*.kicad_sch"), recursive=True):
+        txt = open(f).read()
+        defined = set(re.findall(r'\(symbol\s+"([^"]+)"', txt))
+        instances = set(re.findall(r'\(lib_id\s+"([^"]+)"', txt))
+        missing = sorted(
+            i for i in instances if i.startswith("power:") and i not in defined
+        )
+        if missing:
+            result[os.path.basename(f)] = missing
+    return result
+
+
+def _build_two_stage_power_design(circuit):
+    """Two instances of a stage sharing VCC/GND power nets — hierarchical, so
+    each stage becomes its own sheet and the power nets get auto-stubbed."""
+    with circuit:
+
+        @subcircuit
+        def stage():
+            vcc, gnd, sig = Net("VCC"), Net("GND"), Net()
+            r1 = Part("Device", "R")
+            r2 = Part("Device", "R")
+            c1 = Part("Device", "C")
+            vcc & r1 & sig & r2 & gnd
+            sig & c1 & gnd
+            return Interface(vcc=vcc, gnd=gnd)
+
+        vcc, gnd = Net("VCC"), Net("GND")
+        s1 = stage()
+        s2 = stage()
+        s1.vcc += vcc
+        s2.vcc += vcc
+        s1.gnd += gnd
+        s2.gnd += gnd
+
+
+@requires_kicad_libs
+def test_power_symbol_defs_complete_under_autostub(output_dir):
+    """Every power-symbol instance must have a matching lib_symbols definition on
+    the same sheet (regression: development dropped them on stubbed child sheets)."""
+    circuit = Circuit(name="two_stage_power")
+    _build_two_stage_power_design(circuit)
+    circuit.generate_schematic(
+        filepath=output_dir, top_name="two_stage_power",
+        auto_stub=True, auto_stub_fanout=2,
+    )
+    missing = _power_symbol_integrity(output_dir)
+    assert not missing, f"power symbols emitted without definitions: {missing}"

--- a/trans-erc.rpt
+++ b/trans-erc.rpt
@@ -1,0 +1,35 @@
+ERC report (2026-05-31T14:43:59+1000, Encoding UTF8)
+
+***** Sheet /
+[pin_not_driven]: Input pin not driven by any Output pins
+    ; error
+    @(123.19 mm, 152.40 mm): Symbol Q_ Pin 2 [B, Input, Line]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(135.89 mm, 58.42 mm): Symbol Q_V [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(129.54 mm, 83.82 mm): Symbol Q_R [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(124.46 mm, 104.14 mm): Symbol Q_HR [Q_PNP_CBE]
+[endpoint_off_grid]: Symbol pin or wire end off connection grid
+    ; warning
+    @(167.64 mm, 111.76 mm): Horizontal Wire, length 32.05 mm
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(124.46 mm, 127.00 mm): Symbol Q_VL [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(158.75 mm, 93.98 mm): Symbol Q_LV [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(147.32 mm, 118.11 mm): Symbol Q_H [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(128.27 mm, 152.40 mm): Symbol Q_ [Q_PNP_CBE]
+[lib_symbol_issues]: The current configuration does not include the symbol library '/usr/share/kicad/symbols/Transistor_BJT'
+    ; warning
+    @(172.72 mm, 114.30 mm): Symbol Q_L [Q_PNP_CBE]
+
+ ** ERC messages: 10  Errors 1  Warnings 9


### PR DESCRIPTION
> ## ⚠️ Merge order — please read first
> This is one of a **4-PR dependency stack that must merge bottom-up in order:**
> **#308 → #309 → #310 → #311**
> All four target `development` directly (GitHub requires the base branch to live in this repo), so until the PRs below this one merge, this PR's diff also shows *their* commits. Each PR's diff cleans up to just its own changes once the ones beneath it land. Do not merge before **#308, #309**.

Two net-label improvements on top of the snap work:

- **Deconfliction:** spread overlapping net labels apart (anchor-preserving — labels wire back to their pin), so dense sheets don't pile labels on part bodies / each other.
- **Orientation:** angle + justification always chosen so label text extends *away* from the pin (clear of the body) for every pin direction including mirrored parts; fixes vertical labels overprinting their own component.

Modest but real on already-decent sheets (current `development` already handles the obvious stub cases). Shown here on a dense charger sheet — overlapping `USB_*` labels separate:
![before/after](https://raw.githubusercontent.com/lachlanfysh/skidl/302-assets/pr-ladder-renders/PR3_label-orientation.png)

Test: `test_net_labels_do_not_point_into_parts`.

---
*Part 3 of 4. Stacks on #308 + the snap PR. Draft until those merge.*
