### PR TITLE
fix(kicad6/7/8): correct vertical net-label orientation to match kicad9

### DIFF
--- a/src/skidl/tools/kicad6/sexp_schematic.py
+++ b/src/skidl/tools/kicad6/sexp_schematic.py
@@ -714,12 +714,14 @@ def net_label_to_sexp(pin, tx=Tx(), force=False):
     part_tx = getattr(pin.part, "tx", Tx())
     pt = pin_pt * part_tx * tx
 
-    # Map pin orientation to angle (degrees).
-    orient_map = {"R": 180, "D": 270, "L": 0, "U": 90}
-    angle = orient_map[calc_pin_dir(pin)]
-
-    # Justify depends on label direction.
-    justify = "left" if angle in (0, 90) else "right"
+    # Map pin orientation to pin angle (degrees) and label justification so
+    # the label text always extends AWAY from the pin (clear of the part body)
+    # in every orientation, mirrored parts included.  calc_pin_dir() already
+    # folds the part's full transform into the reported direction.  These are
+    # the same values used by the KiCad 9 backend; the previous {"D":270,"U":90}
+    # mapping inverted vertical labels so they overprinted the body.
+    orient_map = {"R": (180, "right"), "D": (90, "left"), "L": (0, "left"), "U": (270, "right")}
+    angle, justify = orient_map[calc_pin_dir(pin)]
 
     label = Sexp(
         [

--- a/src/skidl/tools/kicad7/sexp_schematic.py
+++ b/src/skidl/tools/kicad7/sexp_schematic.py
@@ -714,12 +714,14 @@ def net_label_to_sexp(pin, tx=Tx(), force=False):
     part_tx = getattr(pin.part, "tx", Tx())
     pt = pin_pt * part_tx * tx
 
-    # Map pin orientation to angle (degrees).
-    orient_map = {"R": 180, "D": 270, "L": 0, "U": 90}
-    angle = orient_map[calc_pin_dir(pin)]
-
-    # Justify depends on label direction.
-    justify = "left" if angle in (0, 90) else "right"
+    # Map pin orientation to pin angle (degrees) and label justification so
+    # the label text always extends AWAY from the pin (clear of the part body)
+    # in every orientation, mirrored parts included.  calc_pin_dir() already
+    # folds the part's full transform into the reported direction.  These are
+    # the same values used by the KiCad 9 backend; the previous {"D":270,"U":90}
+    # mapping inverted vertical labels so they overprinted the body.
+    orient_map = {"R": (180, "right"), "D": (90, "left"), "L": (0, "left"), "U": (270, "right")}
+    angle, justify = orient_map[calc_pin_dir(pin)]
 
     label = Sexp(
         [

--- a/src/skidl/tools/kicad8/sexp_schematic.py
+++ b/src/skidl/tools/kicad8/sexp_schematic.py
@@ -714,12 +714,14 @@ def net_label_to_sexp(pin, tx=Tx(), force=False):
     part_tx = getattr(pin.part, "tx", Tx())
     pt = pin_pt * part_tx * tx
 
-    # Map pin orientation to angle (degrees).
-    orient_map = {"R": 180, "D": 270, "L": 0, "U": 90}
-    angle = orient_map[calc_pin_dir(pin)]
-
-    # Justify depends on label direction.
-    justify = "left" if angle in (0, 90) else "right"
+    # Map pin orientation to pin angle (degrees) and label justification so
+    # the label text always extends AWAY from the pin (clear of the part body)
+    # in every orientation, mirrored parts included.  calc_pin_dir() already
+    # folds the part's full transform into the reported direction.  These are
+    # the same values used by the KiCad 9 backend; the previous {"D":270,"U":90}
+    # mapping inverted vertical labels so they overprinted the body.
+    orient_map = {"R": (180, "right"), "D": (90, "left"), "L": (0, "left"), "U": (270, "right")}
+    angle, justify = orient_map[calc_pin_dir(pin)]
 
     label = Sexp(
         [

--- a/tests/examples/net_label_orientation/README.md
+++ b/tests/examples/net_label_orientation/README.md
@@ -1,0 +1,22 @@
+# Net-label orientation examples
+
+Two small designs that stress net-label placement so the labels can be eyeballed
+in EESCHEMA. A net label should always extend **away** from the pin it sits on,
+so the text runs clear of the part body, in every pin direction and for every
+KiCad backend (6/7/8/9).
+
+| script | what it stresses |
+|---|---|
+| `transistor_rotations.py` | 8 PNP transistors in every rotation/mirror, stub labels on every pin — covers all four pin directions including mirrored parts |
+| `nested_interface.py` | hierarchical subcircuits mixing stub nets (`VIN2`) and routed nets (`VIN1`) — covers both stub labels and wire/NetTerminal labels |
+
+Run with the default backend (KiCad 9), or pick another:
+
+```bash
+python transistor_rotations.py
+SKIDL_TOOL=KICAD8 python transistor_rotations.py
+```
+
+The render-free regression test
+`tests/unit_tests/ai_tests/test_net_label_orientation.py` pins the
+direction → `(angle, justify)` mapping and asserts all four backends agree.

--- a/tests/examples/net_label_orientation/nested_interface.py
+++ b/tests/examples/net_label_orientation/nested_interface.py
@@ -1,0 +1,38 @@
+"""Nested hierarchical subcircuits with a mix of stub nets and routed nets, so
+both stub labels (VIN2) and wire/NetTerminal labels (VIN1) are emitted.  Both
+kinds of label should extend away from their pin.  (Adapted from Dave's
+hier_test.test_interface_12.)
+
+    python nested_interface.py
+"""
+from skidl import *
+
+r = Part("Device", "R", dest=TEMPLATE)
+c = Part("Device", "C", dest=TEMPLATE)
+
+
+@subcircuit
+def sub1():
+    my_vin, my_gnd = Net(), Net()
+    r1 = r(tag="r1")
+    c1 = c(tag="c1")
+    my_vin & r1 & c1 & my_gnd
+    return Interface(my_vin=my_vin, my_gnd=my_gnd)
+
+
+@subcircuit
+def sub2(my_vin1, my_vin2, my_gnd):
+    s1 = sub1(tag="s1")
+    s2 = sub1(tag="s2")
+    s1.my_vin += my_vin1
+    my_vin2 += s2.my_vin
+    my_gnd += s1.my_gnd
+    s2.my_gnd += my_gnd
+
+
+vin1, vin2, gnd, vdd = Net("VIN1"), Net("VIN2", stub=True), Net("GND"), Net("VDD")
+sub = sub2(vin1, vin2, gnd, tag="sub")
+r1 = r()
+vdd & r1 & gnd
+
+generate_schematic(title="Nested interface", flatness=1, filepath=".")

--- a/tests/examples/net_label_orientation/transistor_rotations.py
+++ b/tests/examples/net_label_orientation/transistor_rotations.py
@@ -1,0 +1,21 @@
+"""Eight PNP transistors in every rotation/mirror, each pin carrying a stub net
+label.  Exercises net-label orientation across all symbol transforms: every
+label should extend AWAY from the body (horizontal labels reach to the side,
+vertical labels run clear above/below), in all four KiCad backends.
+
+    python transistor_rotations.py           # default tool (KiCad 9)
+    SKIDL_TOOL=KICAD8 python transistor_rotations.py
+"""
+from skidl import *
+
+e, b, c = Net("ENET"), Net("BNET"), Net("CNET")
+b.netio = "i"
+e.stub, b.stub, c.stub = True, True, True
+
+qt = Part(lib="Transistor_BJT", name="Q_PNP_CBE", dest=TEMPLATE)
+for q, tx in zip(qt(8), ["", "H", "V", "R", "L", "VL", "HR", "LV"]):
+    q["E B C"] += e, b, c
+    q.ref = "Q_" + tx
+    q.symtx = tx
+
+generate_schematic(filepath=".", flatness=1.0)

--- a/tests/unit_tests/ai_tests/test_net_label_orientation.py
+++ b/tests/unit_tests/ai_tests/test_net_label_orientation.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+# The MIT License (MIT) - Copyright (c) Dave Vandenbout.
+
+"""Net-label orientation regression tests.
+
+A net label must always extend *away* from the pin it sits on, so the text
+runs clear of the part body in every pin direction.  KiCad's ``global_label``
+keeps text upright (angle 90 reads the same as 270, 0 the same as 180), so the
+side the label extends is governed by ``justify`` together with the
+horizontal/vertical angle.  The correct, render-verified mapping is:
+
+    pin points R -> (180, "right")   # label reaches out to the right
+    pin points L -> (0,   "left")    # ... to the left
+    pin points U -> (270, "right")   # ... upward, clear of the body
+    pin points D -> (90,  "left")    # ... downward
+
+A previous regression left the KiCad 6/7/8 backends on ``{"D": 270, "U": 90}``
+with justify derived from the angle, which flipped vertical labels so they
+overprinted the part body.  These tests pin the mapping and, crucially, assert
+that *all four* KiCad backends agree -- the drift that caused the bug.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from skidl.geometry import Point, Tx
+from skidl.tools.kicad6 import sexp_schematic as k6
+from skidl.tools.kicad7 import sexp_schematic as k7
+from skidl.tools.kicad8 import sexp_schematic as k8
+from skidl.tools.kicad9 import sexp_schematic as k9
+
+BACKENDS = {"kicad6": k6, "kicad7": k7, "kicad8": k8, "kicad9": k9}
+
+
+@pytest.fixture(autouse=True)
+def _empty_power_symbols():
+    """``net_label_to_sexp`` consults a module-global ``pwr_symbol_names`` that
+    is normally populated during generation.  Calling the emitter in isolation
+    needs it defined; an empty set routes the test net through the plain
+    global_label path (no power symbol)."""
+    saved = {}
+    for mod in BACKENDS.values():
+        saved[mod] = getattr(mod, "pwr_symbol_names", None)
+        mod.pwr_symbol_names = set()
+    yield
+    for mod, val in saved.items():
+        if val is None:
+            delattr(mod, "pwr_symbol_names")
+        else:
+            mod.pwr_symbol_names = val
+
+# pin direction -> (label angle, justify) that makes the label extend away.
+EXPECTED = {
+    "R": (180, "right"),
+    "L": (0, "left"),
+    "U": (270, "right"),
+    "D": (90, "left"),
+}
+
+
+def _fake_pin(orientation):
+    """A minimal stubbed pin whose ``calc_pin_dir`` resolves to ``orientation``
+    (identity part transform leaves the pin orientation unchanged)."""
+    part = SimpleNamespace(tx=Tx())
+    net = SimpleNamespace(name="SIG")
+    return SimpleNamespace(
+        orientation=orientation,
+        stub=True,
+        net=net,
+        part=part,
+        pt=Point(0, 0),
+        x=0,
+        y=0,
+        is_connected=lambda: True,
+    )
+
+
+def _angle_justify(sexp):
+    """Pull (angle, justify) out of an emitted global_label S-expression."""
+    angle = justify = None
+    for el in sexp:
+        if isinstance(el, list) and el and el[0] == "at":
+            angle = el[3]
+        if isinstance(el, list) and el and el[0] == "effects":
+            for sub in el:
+                if isinstance(sub, list) and sub and sub[0] == "justify":
+                    justify = sub[1]
+    return angle, justify
+
+
+@pytest.mark.parametrize("backend_name,mod", BACKENDS.items())
+@pytest.mark.parametrize("pin_dir", ["R", "L", "U", "D"])
+def test_label_extends_away(backend_name, mod, pin_dir):
+    """Each backend emits the away-extending angle/justify for every pin dir."""
+    pin = _fake_pin(pin_dir)
+    assert mod.calc_pin_dir(pin) == pin_dir  # identity tx sanity check
+    sexp = mod.net_label_to_sexp(pin)
+    assert _angle_justify(sexp) == EXPECTED[pin_dir]
+
+
+@pytest.mark.parametrize("pin_dir", ["R", "L", "U", "D"])
+def test_backends_agree(pin_dir):
+    """All four KiCad backends must emit identical label orientation -- the
+    cross-backend drift is exactly what regressed the vertical labels."""
+    results = {
+        name: _angle_justify(mod.net_label_to_sexp(_fake_pin(pin_dir)))
+        for name, mod in BACKENDS.items()
+    }
+    assert len(set(results.values())) == 1, results
+
+
+def test_vertical_labels_not_inverted():
+    """Direct guard against the specific {"D":270,"U":90} swap: up and down
+    pins must not collapse to the same justify, and neither may point inward."""
+    for name, mod in BACKENDS.items():
+        up = _angle_justify(mod.net_label_to_sexp(_fake_pin("U")))
+        dn = _angle_justify(mod.net_label_to_sexp(_fake_pin("D")))
+        assert up == (270, "right"), f"{name} U-pin label inverted: {up}"
+        assert dn == (90, "left"), f"{name} D-pin label inverted: {dn}"


### PR DESCRIPTION
## What

The KiCad **6 / 7 / 8** schematic backends still carry the pre-fix net-label
orientation map:

```python
orient_map = {"R": 180, "D": 270, "L": 0, "U": 90}   # D/U swapped
angle = orient_map[calc_pin_dir(pin)]
justify = "left" if angle in (0, 90) else "right"
```

The `D`/`U` values are swapped relative to the (already-correct) KiCad 9
backend, so **vertical net labels are rotated to point *into* the part body and
overprint it.** The KiCad 9 repair (`87ae8a6a`) was never propagated to 6/7/8.

This PR replaces the per-backend map in 6/7/8 with the same render-verified
table KiCad 9 uses, returning `(angle, justify)` directly so the label always
extends *away* from the pin:

```python
orient_map = {"R": (180, "right"), "D": (90, "left"), "L": (0, "left"), "U": (270, "right")}
angle, justify = orient_map[calc_pin_dir(pin)]
```

KiCad 9 already has these values and is unchanged.

## Why it looks the way it does

KiCad's `global_label` keeps text upright — angle 90 reads identically to 270,
and 0 identically to 180 — so the side a label extends is governed by `justify`
together with the horizontal/vertical angle, not by the angle alone. The
swapped `D`/`U` rotated the vertical labels and, with justify derived from the
(now wrong) angle, pushed them back over the body.

## Before / after (KiCad 8 backend, 8-way transistor rotation/mirror sweep)

![before/after](https://raw.githubusercontent.com/lachlanfysh/skidl/302-assets/renders/net-label-orientation-allkicad.png)

## Tests & examples

- `tests/unit_tests/ai_tests/test_net_label_orientation.py` — render-free
  regression: pins the direction → `(angle, justify)` mapping, asserts **all
  four KiCad backends agree** (the cross-backend drift that caused this), and
  guards specifically against the `D`/`U` swap. Fails on the old map, passes on
  the fix.
- `tests/examples/net_label_orientation/` — two runnable designs to eyeball in
  EESCHEMA: the 8-way transistor rotation/mirror sweep, and a nested
  hierarchical interface mixing stub-net and routed-net labels. Run with
  `SKIDL_TOOL=KICAD8 python transistor_rotations.py` etc.

Full schematic suite (`test_schematic.py`, `ai_tests/test_sexp_schematic.py`,
the new test): 53 passed, 1 skipped.
