### PR TITLE
Fix netlist_to_skidl crash on KiCad 10 netlists: guard value-less boolean properties in PropertySexp

### DIFF
--- a/src/skidl/netlist_to_skidl.py
+++ b/src/skidl/netlist_to_skidl.py
@@ -146,7 +146,10 @@ class PropertySexp:
 
     def __init__(self, sexp):
         self.name = sexp.search("/property/name").value
-        self.value = sexp.search("/property/value").value
+        # KiCad can export boolean properties (e.g. exclude_from_bom) without
+        # a value, so treat a missing value as an empty string.
+        found = sexp.search("/property/value")
+        self.value = found.value if len(found) else ""
 
 
 class PinSexp:

--- a/tests/unit_tests/test_parse.py
+++ b/tests/unit_tests/test_parse.py
@@ -5,6 +5,7 @@
 import pytest
 
 from skidl import Part, netlist_to_skidl, generate_netlist, TEMPLATE, Net, subcircuit
+from skidl.netlist_to_skidl import HierarchicalConverter
 
 
 def test_parser_1():
@@ -59,3 +60,65 @@ def test_parser_1():
 
     # Check that the original and new circuits are the same.
     assert original_tuple == new_tuple
+
+
+def test_parser_boolean_property_without_value():
+    """Test parsing a netlist with a property that has no value.
+
+    KiCad 10 exports boolean component properties (e.g. exclude_from_bom,
+    exclude_from_sim) as `(property (name "..."))` without a `(value ...)`
+    child. The parser must treat the missing value as an empty string
+    instead of crashing.
+    """
+
+    # Minimal KiCad 10 style netlist with a valueless boolean property.
+    netlist = """
+(export
+    (version "E")
+    (design
+        (source "test.kicad_sch")
+        (date "2026-07-02T16:56:33")
+        (tool "Eeschema 10.0.3")
+        (sheet
+            (number "1")
+            (name "/")
+            (tstamps "/")))
+    (components
+        (comp
+            (ref "P5")
+            (value "MOUNTING_HOLE")
+            (footprint "Footprints:MountingHole_3.2mm_M3_DIN965_Pad")
+            (libsource
+                (lib "ecc83-pp")
+                (part "CONN_1")
+                (description ""))
+            (property
+                (name "Sheetname")
+                (value ""))
+            (property
+                (name "exclude_from_bom"))
+            (sheetpath
+                (names "/")
+                (tstamps "/"))
+            (tstamps "00000000-0000-0000-0000-000054a5890a")))
+    (nets
+        (net
+            (code "1")
+            (name "GND")
+            (class "Default")
+            (node
+                (ref "P5")
+                (pin "1")
+                (pintype "passive")))))
+"""
+
+    # Parsing must not raise and the boolean property value must be "".
+    converter = HierarchicalConverter(netlist)
+    part = converter.netlist.parts[0]
+    prop_values = {prop.name: prop.value for prop in part.properties}
+    assert prop_values["exclude_from_bom"] == ""
+    assert prop_values["Sheetname"] == ""
+
+    # The full netlist-to-SKiDL conversion must also succeed.
+    code = netlist_to_skidl(netlist)
+    assert "P5" in code


### PR DESCRIPTION
## Problem

`netlist_to_skidl()` raises
`ValueError: Sexp isn't in a form that permits extracting a single value.`
when the input netlist was exported by KiCad 10.

KiCad 10 writes *boolean-style* component properties (e.g.
`exclude_from_bom`, `exclude_from_sim`) **without a `value` child node**:

```lisp
(property
    (name "Sheetfile")
    (value "ecc83-pp.kicad_sch")
)
(property
    (name "exclude_from_bom")
)
```

Any netlist containing e.g. a mounting hole marked "exclude from BOM" is
unconvertible. The KiCad 10 bundled demo `demos/ecc83/ecc83-pp.kicad_sch`
(mounting holes P5..P8 carry `exclude_from_bom`) reproduces it directly:

```python
from skidl.netlist_to_skidl import netlist_to_skidl
netlist_to_skidl("ecc83-pp.net", "out_dir")   # exported by kicad-cli 10.0.3
```

Traceback (tail):

```
File "skidl\netlist_to_skidl.py", line 149, in __init__
    self.value = sexp.search("/property/value").value
ValueError: Sexp isn't in a form that permits extracting a single value.
```

Reproduced on 2.2.3 and on current `master`
(`e19d9a6a68f6370bd841cc946c97c9a05ee21567`; `git diff v2.2.3..master` has no
changes under `src/` or `tests/`, so release and master behave the same).

## Root cause

`PropertySexp.__init__` (`src/skidl/netlist_to_skidl.py`, line ~149)
unconditionally extracts a single value:

```python
self.value = sexp.search("/property/value").value
```

For the value-less property form, `search()` returns an empty result and
its `.value` accessor raises `ValueError`.

## Fix

One guarded lookup in `PropertySexp.__init__`, falling back to an empty
string so value-less boolean properties parse instead of crashing:

```diff
-        self.value = sexp.search("/property/value").value
+        # KiCad can export boolean properties (e.g. exclude_from_bom) without
+        # a value, so treat a missing value as an empty string.
+        found = sexp.search("/property/value")
+        self.value = found.value if len(found) else ""
```

## Regression test

`tests/unit_tests/test_parse.py::test_parser_boolean_property_without_value`
— feeds a minimal KiCad-10-style netlist string containing one component
whose `exclude_from_bom` property has **no** `(value ...)` child, plus a
conventional property with an explicit value node as a control, and one net.
Asserts that the netlist parses, the value-less property yields `""`, the
control property parses as before, and the full `netlist_to_skidl`
conversion emits the component.

Run in a clean venv (Python 3.12.3, pytest 9.1.1, `pip install -e .`):

- **Red** (without the guard): the test fails with the reported crash —
  `PropertySexp.__init__` → `ValueError: Sexp isn't in a form that permits
  extracting a single value.` (`1 failed in 0.09s`).
- **Green** (with the guard): `1 passed in 0.11s`.
- **Full suite** (`tests/unit_tests`, 477 items): results identical to the
  unpatched baseline except the new test passing — the same set of
  pre-existing environment-specific failures (missing optional
  graphviz/pcbnew dependencies, platform path quirks) on both sides, zero
  new failures.

## Backward compatibility

- Properties **with** a `(value ...)` child parse exactly as before; the
  guard only changes behavior for the previously-crashing value-less form.
- Value-less properties now yield `""`, matching how KiCad itself displays
  an empty property value, and matching the pre-normalization workaround
  (rewriting `(property (name "X"))` to `(property (name "X") (value ""))`)
  that produced correct conversions.
- No public API change; the fix is a single guarded expression inside
  `PropertySexp.__init__`.
- The diff is kept minimal: surrounding code is not reformatted, and the
  added lines themselves follow black style.

---

*The full KiCad 10 netlist, its normalized variant, and the generated
output are available on request.*
