### PR TITLE
fix(netlist_to_skidl): guard value-less KiCad 10 boolean properties

### DIFF
--- a/src/skidl/netlist_to_skidl.py
+++ b/src/skidl/netlist_to_skidl.py
@@ -154,10 +154,7 @@ class PartSexp:
             self.lib = sexp.search("/comp/libsource/lib").value
         except ValueError:
             self.lib = ""
-        try:
-            self.properties = [PropertySexp(prop) for prop in sexp.search("/comp/property")]
-        except ValueError:
-            self.properties = []
+        self.properties = [PropertySexp(prop) for prop in sexp.search("/comp/property")]
 
 
 class PropertySexp:
@@ -167,7 +164,10 @@ class PropertySexp:
 
     def __init__(self, sexp):
         self.name = sexp.search("/property/name").value
-        self.value = sexp.search("/property/value").value
+        # KiCad can export boolean properties (e.g. exclude_from_bom) without
+        # a value, so treat a missing value as an empty string.
+        found = sexp.search("/property/value")
+        self.value = found.value if len(found) else ""
 
 
 class PinSexp:
@@ -234,7 +234,6 @@ class HierarchicalConverter:
         self.netlist = NetlistSexp(Sexp(text))
         self.sheets = {}
         self.tab = " " * 4
-
 
     def find_lowest_common_ancestor(self, sheet1, sheet2):
         """

--- a/tests/unit_tests/test_parse.py
+++ b/tests/unit_tests/test_parse.py
@@ -5,6 +5,7 @@
 import pytest
 
 from skidl import Part, netlist_to_skidl, generate_netlist, TEMPLATE, Net, subcircuit
+from skidl.netlist_to_skidl import HierarchicalConverter
 
 
 def test_parser_1():
@@ -48,14 +49,77 @@ def test_parser_1():
     # Import and execute the generated SKiDL code.
     import sys
     import os
+
     sys.path.insert(0, os.path.abspath("./test_parser_1"))
     import test_parser_1
 
     # Get the default circuit created by the generated SKiDL code.
-    new_circuit = test_parser_1.__builtins__['default_circuit']
+    new_circuit = test_parser_1.__builtins__["default_circuit"]
 
     # Get comparison tuple for the reconstructed circuit.
-    new_tuple =  new_circuit.to_tuple()
+    new_tuple = new_circuit.to_tuple()
 
     # Check that the original and new circuits are the same.
     assert original_tuple == new_tuple
+
+
+def test_parser_boolean_property_without_value():
+    """Test parsing a netlist with a property that has no value.
+
+    KiCad 10 exports boolean component properties (e.g. exclude_from_bom,
+    exclude_from_sim) as `(property (name "..."))` without a `(value ...)`
+    child. The parser must treat the missing value as an empty string
+    instead of crashing. (Upstream issue: devbisme/skidl PR #317.)
+    """
+
+    # Minimal KiCad 10 style netlist with a valueless boolean property.
+    netlist = """
+(export
+    (version "E")
+    (design
+        (source "test.kicad_sch")
+        (date "2026-07-02T16:56:33")
+        (tool "Eeschema 10.0.3")
+        (sheet
+            (number "1")
+            (name "/")
+            (tstamps "/")))
+    (components
+        (comp
+            (ref "P5")
+            (value "MOUNTING_HOLE")
+            (footprint "Footprints:MountingHole_3.2mm_M3_DIN965_Pad")
+            (libsource
+                (lib "ecc83-pp")
+                (part "CONN_1")
+                (description ""))
+            (property
+                (name "Sheetname")
+                (value ""))
+            (property
+                (name "exclude_from_bom"))
+            (sheetpath
+                (names "/")
+                (tstamps "/"))
+            (tstamps "00000000-0000-0000-0000-000054a5890a")))
+    (nets
+        (net
+            (code "1")
+            (name "GND")
+            (class "Default")
+            (node
+                (ref "P5")
+                (pin "1")
+                (pintype "passive")))))
+"""
+
+    # Parsing must not raise and the boolean property value must be "".
+    converter = HierarchicalConverter(netlist)
+    part = converter.netlist.parts[0]
+    prop_values = {prop.name: prop.value for prop in part.properties}
+    assert prop_values["exclude_from_bom"] == ""
+    assert prop_values["Sheetname"] == ""
+
+    # The full netlist-to-SKiDL conversion must also succeed.
+    code = netlist_to_skidl(netlist)
+    assert "P5" in code


### PR DESCRIPTION
I looked this over. It looks reasonable, and runs on my system. The remainder is AI generated.

KiCad 10 exports boolean component properties (e.g. exclude_from_bom, exclude_from_sim) as `(property (name "..."))` with no `(value ...)` child, which made PropertySexp raise "Sexp isn't in a form that permits extracting a single value" and rendered any such netlist unconvertible by netlist_to_skidl.

Adopt the per-property guard from upstream PR #317: a missing value becomes "" so the rest of the component's properties are preserved (replacing the previous coarse PartSexp try/except that dropped ALL properties on the first failure). Adds test_parser_boolean_property_without_value mirroring the PR's fixture.

Addresses devbisme/skidl PR #317.