### PR TITLE
Fix KiCad 8 library symbol grammar

### DIFF
--- a/src/skidl/tools/kicad8/sexp_schematic.py
+++ b/src/skidl/tools/kicad8/sexp_schematic.py
@@ -619,7 +619,7 @@ def part_to_lib_symbol_definition(part):
     symbol_def = [
         "symbol",
         lib_id,
-        ["pin_numbers", ["hide", "yes"]],
+        ["pin_numbers", "hide"],
         ["pin_names", ["offset", 0]],
         ["exclude_from_sim", "no"],
         ["in_bom", "yes"],
@@ -696,8 +696,6 @@ def part_to_lib_symbol_definition(part):
                 unit_sym.extend(graphics)
                 unit_sym.extend(pin_cmds)
                 symbol_def.append(unit_sym)
-
-    symbol_def.append(["embedded_fonts", "no"])
 
     return symbol_def
 

--- a/tests/unit_tests/ai_tests/test_sexp_schematic.py
+++ b/tests/unit_tests/ai_tests/test_sexp_schematic.py
@@ -16,11 +16,15 @@ import shutil
 import subprocess
 import tempfile
 import uuid
+from types import SimpleNamespace
 
 import pytest
 
 from skidl import get_default_tool
 from skidl.geometry import BBox, Point, Tx
+from skidl.tools.kicad8.sexp_schematic import (
+    part_to_lib_symbol_definition as part_to_kicad8_lib_symbol_definition,
+)
 
 tool = get_default_tool()
 sexp_schematic = importlib.import_module(f"skidl.tools.{tool}.sexp_schematic")
@@ -159,6 +163,30 @@ class TestTitleBlock:
         # Should have a date entry.
         dates = [item for item in tb if isinstance(item, list) and item[0] == "date"]
         assert len(dates) == 1
+
+
+class TestLibrarySymbolDefinition:
+    """Tests for backend-specific library symbol grammar."""
+
+    def test_kicad8_uses_legacy_pin_number_syntax(self):
+        """KiCad 8 symbols omit grammar tokens introduced in KiCad 9."""
+        part = SimpleNamespace(
+            lib=SimpleNamespace(filename="Device.kicad_sym"),
+            name="R",
+            ref_prefix="R",
+            datasheet="~",
+            description="Resistor",
+            draw_cmds={},
+        )
+
+        symbol_def = part_to_kicad8_lib_symbol_definition(part)
+
+        assert ["pin_numbers", "hide"] in symbol_def
+        assert ["pin_numbers", ["hide", "yes"]] not in symbol_def
+        assert not any(
+            isinstance(entry, list) and entry and entry[0] == "embedded_fonts"
+            for entry in symbol_def
+        )
 
 
 class TestFixSheetFilename:


### PR DESCRIPTION
Fixes #322.

KiCad 8 refuses to open schematics generated by the `kicad8` backend because the library symbols contain two forms introduced in KiCad 9. This writes `pin_numbers` using the syntax KiCad 8 expects and leaves out `embedded_fonts`, which KiCad 8 does not recognize.

I added a regression test against the KiCad 8 writer. The KiCad 9 backend is unchanged.

Tests:

* `SKIDL_TOOL=KICAD8 pytest tests/unit_tests/ai_tests/test_sexp_schematic.py -q` — 32 passed, 4 skipped
* `git diff --check`
